### PR TITLE
Do not move faster when walking diagonally

### DIFF
--- a/src/Scripts/KinematicBody2D.gd
+++ b/src/Scripts/KinematicBody2D.gd
@@ -7,26 +7,29 @@ var id
 var velocity = Vector2(0,0)
 
 func get_input():
-	velocity = Vector2(lerp(velocity.x,0,0.17),lerp(velocity.y,0,0.17))
-	#interpolate velocity:
+	var prev_velocity = velocity
+	velocity = Vector2(0, 0)
 	$Sprite.play("walk")
-	var moving = false
 	if Input.is_action_pressed('ui_right'):
-		velocity.x = speed
+		velocity.x = 1
 		$Sprite.flip_h = false
-		moving = true
 	if Input.is_action_pressed('ui_left'):
-		velocity.x = -speed
+		velocity.x = -1
 		$Sprite.flip_h = true
-		moving = true
 	if Input.is_action_pressed('ui_down'):
-		velocity.y = speed
-		moving = true
+		velocity.y = 1
 	if Input.is_action_pressed('ui_up'):
-		velocity.y = -speed
-		moving = true
-	if not moving:
+		velocity.y = -1
+	velocity = velocity.normalized() * speed
+
+	#interpolate velocity:
+	if velocity.x == 0:
+		velocity.x = lerp(prev_velocity.x, 0, 0.17)
+	if velocity.y == 0:
+		velocity.y = lerp(prev_velocity.y, 0, 0.17)
+	if velocity.length() < 50:
 		$Sprite.play("idle")
+
 func _physics_process(delta):
 	get_input()
 	velocity = move_and_slide(velocity)


### PR DESCRIPTION
The line `velocity = velocity.normalized() * speed` is needed, otherwise diagonal movement is sqrt(2) times faster than going straight.