### PR TITLE
enable scaling for different resolutions

### DIFF
--- a/src/project.godot
+++ b/src/project.godot
@@ -23,6 +23,11 @@ config/icon="res://icon.png"
 
 Network="*res://Scripts/network.gd"
 
+[display]
+
+window/stretch/mode="2d"
+window/stretch/aspect="keep"
+
 [gui]
 
 theme/custom_font="res://Assets/Fonts/menufont.tres"


### PR DESCRIPTION
This keeps the visible content on screen the same regardless of resolution or window size. This is set to keep the original aspect ratio for now. Ideally we would disable having the window resizable and instead offer common resolutions in the ingame settings.