### PR TITLE
New settings system.

### DIFF
--- a/src/scenes/ui/settings.tscn
+++ b/src/scenes/ui/settings.tscn
@@ -3,116 +3,11 @@
 [ext_resource path="res://scripts/settings.gd" type="Script" id=1]
 
 [node name="Settings" type="ScrollContainer"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -512.0
-margin_top = -300.0
-margin_right = 512.0
-margin_bottom = 300.0
+anchor_right = 1.0
+anchor_bottom = 1.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-resDropdown_path = NodePath("VBoxContainer/resDropdown")
-
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
-margin_right = 1024.0
-margin_bottom = 216.0
-size_flags_horizontal = 3
-
-[node name="Fullscreen" type="HBoxContainer" parent="VBoxContainer"]
-margin_right = 1024.0
-margin_bottom = 40.0
-size_flags_horizontal = 3
-
-[node name="Fullscreen" type="Label" parent="VBoxContainer/Fullscreen"]
-margin_top = 9.0
-margin_right = 944.0
-margin_bottom = 31.0
-size_flags_horizontal = 3
-text = "Fullscreen"
-align = 1
-valign = 1
-
-[node name="Fullscreen_toggle" type="CheckButton" parent="VBoxContainer/Fullscreen"]
-margin_left = 948.0
-margin_right = 1024.0
-margin_bottom = 40.0
-
-[node name="Label" type="Label" parent="VBoxContainer"]
-margin_top = 44.0
-margin_right = 1024.0
-margin_bottom = 66.0
-text = "Fullscreen Resolution: "
-
-[node name="resDropdown" type="OptionButton" parent="VBoxContainer"]
-margin_top = 70.0
-margin_right = 1024.0
-margin_bottom = 98.0
-
-[node name="Music Volume" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 102.0
-margin_right = 1024.0
-margin_bottom = 124.0
-
-[node name="MusicLabel" type="Label" parent="VBoxContainer/Music Volume"]
-margin_right = 111.0
-margin_bottom = 22.0
-text = "Music Volume: "
-
-[node name="Music" type="HSlider" parent="VBoxContainer/Music Volume"]
-margin_left = 115.0
-margin_right = 1024.0
-margin_bottom = 16.0
-size_flags_horizontal = 3
-min_value = -24.0
-max_value = 24.0
-
-[node name="Sound Volume" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 128.0
-margin_right = 1024.0
-margin_bottom = 150.0
-
-[node name="SfxLabel" type="Label" parent="VBoxContainer/Sound Volume"]
-margin_right = 114.0
-margin_bottom = 22.0
-text = "Sound Volume: "
-
-[node name="Sound" type="HSlider" parent="VBoxContainer/Sound Volume"]
-margin_left = 118.0
-margin_right = 1024.0
-margin_bottom = 16.0
-size_flags_horizontal = 3
-min_value = -24.0
-max_value = 24.0
-
-[node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 154.0
-margin_right = 1024.0
-margin_bottom = 184.0
-
-[node name="Colorblind Mode" type="Label" parent="VBoxContainer/HBoxContainer3"]
-margin_top = 4.0
-margin_right = 127.0
-margin_bottom = 26.0
-text = "Colorblind Mode: "
-
-[node name="CheckBox" type="CheckBox" parent="VBoxContainer/HBoxContainer3"]
-margin_left = 131.0
-margin_right = 155.0
-margin_bottom = 30.0
-
-[node name="Back" type="Button" parent="VBoxContainer"]
-margin_top = 188.0
-margin_right = 1024.0
-margin_bottom = 216.0
-text = "BACK"
-[connection signal="toggled" from="VBoxContainer/Fullscreen/Fullscreen_toggle" to="." method="_on_Fullscreen_toggle_toggled"]
-[connection signal="item_selected" from="VBoxContainer/resDropdown" to="." method="_on_resDropdown_item_selected"]
-[connection signal="value_changed" from="VBoxContainer/Music Volume/Music" to="." method="_on_Music_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/Sound Volume/Sound" to="." method="_on_Sound_value_changed"]
-[connection signal="pressed" from="VBoxContainer/Back" to="." method="_on_Back_pressed"]

--- a/src/scenes/ui/title.tscn
+++ b/src/scenes/ui/title.tscn
@@ -184,51 +184,11 @@ margin_bottom = 234.0
 
 [node name="Settings" parent="VBoxContainer/MarginContainer/MenuArea" instance=ExtResource( 5 )]
 visible = false
-anchor_left = 0.0
-anchor_top = 0.0
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_left = 64.0
-margin_top = 0.0
 margin_right = 704.0
 margin_bottom = 234.0
-
-[node name="VBoxContainer" parent="VBoxContainer/MarginContainer/MenuArea/Settings" index="0"]
-margin_right = 640.0
-
-[node name="Fullscreen" parent="VBoxContainer/MarginContainer/MenuArea/Settings/VBoxContainer" index="0"]
-margin_right = 164.0
-
-[node name="Fullscreen" parent="VBoxContainer/MarginContainer/MenuArea/Settings/VBoxContainer/Fullscreen" index="0"]
-margin_right = 84.0
-
-[node name="Fullscreen_toggle" parent="VBoxContainer/MarginContainer/MenuArea/Settings/VBoxContainer/Fullscreen" index="1"]
-margin_left = 88.0
-margin_right = 164.0
-
-[node name="Label" parent="VBoxContainer/MarginContainer/MenuArea/Settings/VBoxContainer" index="1"]
-margin_right = 164.0
-
-[node name="resDropdown" parent="VBoxContainer/MarginContainer/MenuArea/Settings/VBoxContainer" index="2"]
-margin_right = 164.0
-
-[node name="Music Volume" parent="VBoxContainer/MarginContainer/MenuArea/Settings/VBoxContainer" index="3"]
-margin_right = 164.0
-
-[node name="Music" parent="VBoxContainer/MarginContainer/MenuArea/Settings/VBoxContainer/Music Volume" index="1"]
-margin_right = 164.0
-
-[node name="Sound Volume" parent="VBoxContainer/MarginContainer/MenuArea/Settings/VBoxContainer" index="4"]
-margin_right = 164.0
-
-[node name="Sound" parent="VBoxContainer/MarginContainer/MenuArea/Settings/VBoxContainer/Sound Volume" index="1"]
-margin_right = 164.0
-
-[node name="HBoxContainer3" parent="VBoxContainer/MarginContainer/MenuArea/Settings/VBoxContainer" index="5"]
-margin_right = 164.0
-
-[node name="Back" parent="VBoxContainer/MarginContainer/MenuArea/Settings/VBoxContainer" index="6"]
-margin_right = 164.0
 
 [node name="PlayGame" parent="VBoxContainer/MarginContainer/MenuArea" instance=ExtResource( 6 )]
 visible = false

--- a/src/scripts/settings.gd
+++ b/src/scripts/settings.gd
@@ -52,6 +52,11 @@ func _ready():
 	if err != OK:
 		raise()
 	
+	# Init back button
+	var back_button = Button.new()
+	back_button.text = "Back"
+	back_button.connect("pressed", get_node(".."), "_on_Return")
+	
 	# Init settings view
 	var vbox = VBoxContainer.new()
 	add_child(vbox)
@@ -79,8 +84,9 @@ func _ready():
 				check_button.pressed = setting.value
 				check_button.connect("pressed", self, "_save_state", [setting.function, check_button, setting])
 				hbox.add_child(check_button)
-
+				
 		vbox.add_child(hbox)
+	vbox.add_child(back_button)
 
 func toggle_colorblind(setting):
 	# apply shader

--- a/src/scripts/settings.gd
+++ b/src/scripts/settings.gd
@@ -1,35 +1,90 @@
-extends ScrollContainer
+extends Control
 
-var music = 10
-var sound = 10
+# Supported nodes
+enum SettingType{
+	SWITCH
+}
 
-export (NodePath) var resDropdown_path
-onready var resDropdown = get_node(resDropdown_path)
+# Init config
+# This should be in start of game
+onready var config = ConfigFile.new()
+
+# Setting class
+class Setting:
+	var default
+	var value
+	var text: String
+	var type: int
+	var function: String
+	var config_name: String
+
+	func _init(default, type, text, function, value=null):
+		self.default = default
+		self.value = value
+		self.type = type
+		self.text = text
+		self.function = function
+
+		# Make this more reliable
+		self.config_name = text.to_lower().replace(" ", "_")
+
+		if value == null:
+			self.value = default
+
+# Wrapper function to save and update setting
+func _save_state(function, node, setting):
+	match setting.type:
+		SettingType.SWITCH:
+			setting.value = node.pressed
+			config.set_value("general", setting.config_name, setting.value)
+
+	config.save("user://settings.cfg")
+	call(function, setting)
+
+var settings = [
+	Setting.new(true, SettingType.SWITCH, tr("Fullscreen"), "toggle_fullscreen"),
+	Setting.new(false, SettingType.SWITCH, tr("Colorblind mode"), "toggle_colorblind"),
+]
 
 func _ready():
-	$VBoxContainer/Back.connect("pressed", get_node(".."), "_on_Return")
-	$VBoxContainer/resDropdown
-	addItems()
+	# Load configuration
+	var err = config.load("user://settings.cfg")
+	if err != OK:
+		raise()
+	
+	# Init settings view
+	var vbox = VBoxContainer.new()
+	add_child(vbox)
 
+	# Mapping settings
+	for setting in settings:
+		if config.has_section_key("general", setting.config_name):
+			setting.value = config.get_value("general", setting.config_name)
+		else:
+			config.set_value("general", setting.config_name, setting.value)
+			
+		# Init row
+		var hbox = HBoxContainer.new()		
 
-func _on_Fullscreen_toggle_toggled(button_pressed):
-	OS.window_fullscreen = button_pressed
+		# Init label with text
+		var new_label = Label.new()
+		new_label.text = setting.text
+		hbox.add_child(new_label)
 
+		call(setting.function, setting)
+		# Add action (Button, CheckBox...)
+		match setting.type:
+			SettingType.SWITCH:
+				var check_button = CheckButton.new()
+				check_button.pressed = setting.value
+				check_button.connect("pressed", self, "_save_state", [setting.function, check_button, setting])
+				hbox.add_child(check_button)
 
-func addItems():
-	resDropdown.add_item("1024x768")
-	resDropdown.add_item("1366x768")
+		vbox.add_child(hbox)
 
+func toggle_colorblind(setting):
+	# apply shader
+	pass
 
-func _on_Music_value_changed(value):
-	music = value
-	emit_signal("button_pressed", "Music")
-
-
-func _on_Sound_value_changed(value):
-	sound = value
-	emit_signal("button_pressed", "Sound")
-
-
-func _on_resDropdown_item_selected(id):
-	pass # Replace with function body.
+func toggle_fullscreen(setting):
+	OS.window_fullscreen = setting.value


### PR DESCRIPTION
New settings system (currently supports only switches)
What works:
- Autosaving 
- Autoloading
- Autogenerating settings screen
- Events
- Switches

What doesn't work:
- Rest of the widgets
- Colorblind (made shader that will come in next pr)
- Ugly UI, but better then before

How to add options:
To add new setting add new element to list like this (currently):
```gdscript
var settings = [
	Setting.new(true, SettingType.SWITCH, tr("Fullscreen"), "toggle_fullscreen"),
	Setting.new(false, SettingType.SWITCH, tr("Colorblind mode"), "toggle_colorblind"),
]
```
First argument is default value
Second argument is node type
Third argument is label displayed
Fourth argument is function name

Next add function:
```gdscript
func toggle_fullscreen(setting):
	OS.window_fullscreen = setting.value
```

Why autosaving works?

Switching CheckButton on or off triggers wrapper function what modifies setting in array and prepares everything for given function and it also **saves** that setting to a file.

Why do we need this?
We need this because this is more modular, cleaner and easier to use