### PR TITLE
Use the players' intended movements for animations instead of the velocities

### DIFF
--- a/src/assets/main/main.gd
+++ b/src/assets/main/main.gd
@@ -41,7 +41,6 @@ func _player_connected(id):
 		rpc_id(id, "player_join", new_player.id)
 
 	players[id] = new_player
-	new_player.scale = Vector2(10, 10) #otherwise the player looks super small
 	add_child(new_player)
 	print("Got connection: ", id)
 	print("Players: ", players)

--- a/src/assets/main/main.gd
+++ b/src/assets/main/main.gd
@@ -62,34 +62,34 @@ remote func player_join(other_id):
 	print("New player: ", other_id)
 
 # Called from client sides when a player moves
-remote func player_moved(new_pos, new_velocity):
+remote func player_moved(new_pos, new_movement):
 	# Should only be run on the server
 	if !get_tree().is_network_server():
 		return
 	var id = get_tree().get_rpc_sender_id()
 	#print("Got player move from ", id) #no reason to spam console so much
 	# Check movement validity here
-	players[id].move_to(new_pos, new_velocity)
+	players[id].move_to(new_pos, new_movement)
 	# The move_to function validates new_x, new_y,
 	# so that's why we don't reuse them
 	new_pos = players[id].position
 	for other_id in players:
 		if id != other_id && other_id != 1:
 			#print("Sending player moved to client ", other_id) #no reason to spam console so much
-			rpc_id(other_id, "other_player_moved", id, new_pos, new_velocity)
+			rpc_id(other_id, "other_player_moved", id, new_pos, new_movement)
 
 # Called from server when other players move
-remote func other_player_moved(id, new_pos, new_velocity):
+remote func other_player_moved(id, new_pos, new_movement):
 	# Should only be run on the client
 	if get_tree().is_network_server():
 		return
 	#print("Moving ", id, " to ", new_pos.x, ", ", new_pos.y) #no reason to spam console so much
-	players[id].move_to(new_pos, new_velocity)
+	players[id].move_to(new_pos, new_movement)
 
-func _on_main_player_moved(position : Vector2, velocity : Vector2):
+func _on_main_player_moved(position : Vector2, movement : Vector2):
 	#In the beginning Godot created the heaven and the earth
 	#about 100% of the fix for the "host invisible" bug
 	if not get_tree().is_network_server():
-		rpc_id(1, "player_moved", position, velocity)
+		rpc_id(1, "player_moved", position, movement)
 	else:
-		rpc("other_player_moved", 1, position, velocity)
+		rpc("other_player_moved", 1, position, movement)

--- a/src/assets/main/main.tscn
+++ b/src/assets/main/main.tscn
@@ -28,6 +28,6 @@ shape = SubResource( 1 )
 
 [node name="Player" parent="." instance=ExtResource( 1 )]
 position = Vector2( -911.138, 148.324 )
-scale = Vector2( 10, 10 )
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
+current = true

--- a/src/assets/player/player.gd
+++ b/src/assets/player/player.gd
@@ -43,13 +43,9 @@ func get_input():
 
 func _physics_process(delta):
 	if main_player:
-		$Camera2D.current = true
 		get_input()
 		velocity = move_and_slide(velocity)
 		emit_signal("main_player_moved", position, velocity)
-	else:
-		return #Camera2D does not exist for newly created players, and crashes the game
-		$Camera2D.current = false
 
 	# We handle animations and stuff here
 	if velocity.x > x_anim_margin:

--- a/src/assets/player/player.gd
+++ b/src/assets/player/player.gd
@@ -7,11 +7,13 @@ export (int) var speed = 150
 # Set by main.gd. Is the client's unique id for this player
 var id
 var velocity = Vector2(0,0)
+# Contains the current intended movement direction and magnitude in range 0 to 1
+var movement = Vector2(0,0)
 # Only true when this is the player being controlled
 var main_player = true
-#anim margin controls how big the player velocity must be before animations are played
-var x_anim_margin = 50
-var y_anim_margin = 50
+#anim margin controls how big the player movement must be before animations are played
+var x_anim_margin = 0.1
+var y_anim_margin = 0.1
 
 func _ready():
 	if "--server" in OS.get_cmdline_args():
@@ -20,20 +22,21 @@ func _ready():
 # Only called when main_player is true
 func get_input():
 	var prev_velocity = velocity
-	velocity = Vector2(0, 0)
+	movement = Vector2(0, 0)
 	if Input.is_action_pressed('ui_right'):
-		velocity.x = 1
+		movement.x = 1
 	if Input.is_action_pressed('ui_left'):
-		velocity.x = -1
+		movement.x = -1
 	if Input.is_action_pressed('ui_down'):
-		velocity.y = 1
+		movement.y = 1
 	if Input.is_action_pressed('ui_up'):
-		velocity.y = -1
+		movement.y = -1
+	movement = movement.normalized()
 
 		#we did it boys, micheal jackson is no more
 #		$Sprite.play("walk-up") for some reason having this makes it not work
 
-	velocity = velocity.normalized() * speed
+	velocity = movement * speed
 
 	#interpolate velocity:
 	if velocity.x == 0:
@@ -45,23 +48,23 @@ func _physics_process(delta):
 	if main_player:
 		get_input()
 		velocity = move_and_slide(velocity)
-		emit_signal("main_player_moved", position, velocity)
+		emit_signal("main_player_moved", position, movement)
 
 	# We handle animations and stuff here
-	if velocity.x > x_anim_margin:
+	if movement.x > x_anim_margin:
 		$Sprite.play("walk-h")
 		$Sprite.flip_h = false
-	elif velocity.x < -x_anim_margin:
+	elif movement.x < -x_anim_margin:
 		$Sprite.play("walk-h")
 		$Sprite.flip_h = true
-	elif velocity.y > y_anim_margin:
+	elif movement.y > y_anim_margin:
 		$Sprite.play("walk-down")
-	elif velocity.y < -y_anim_margin:
+	elif movement.y < -y_anim_margin:
 		$Sprite.play("walk-up")
 	else:
 		$Sprite.play("idle")
 
-func move_to(new_pos, new_velocity):
+func move_to(new_pos, new_movement):
 	# Movement check here
 	position = new_pos
-	velocity = new_velocity
+	movement = new_movement

--- a/src/assets/player/player.tscn
+++ b/src/assets/player/player.tscn
@@ -45,7 +45,7 @@ animations = [ {
 } ]
 
 [node name="Player" type="KinematicBody2D"]
-scale = Vector2( 0.6, 0.6 )
+scale = Vector2( 10, 10 )
 collision_layer = 2
 script = ExtResource( 1 )
 


### PR DESCRIPTION
The movement value fits also well for a client-server multiplayer architecture. The player can send the movement value to the server and the server can validate it easily.

The players can now walk against walls.

![walking against a wall](https://user-images.githubusercontent.com/16741932/96145526-f8e9de80-0f0d-11eb-851a-bf5d3275abc7.png)

Please only push functioning code! The first commit of this PR took way too much time to make. Bisecting is almost impossible because there are so many untested commits that don't work.