### PR TITLE
Fix FSM syncing and improve role assignment

### DIFF
--- a/src/assets/autoload/gamemanager.gd
+++ b/src/assets/autoload/gamemanager.gd
@@ -14,9 +14,9 @@ const TRANSITIONS = {
 signal state_changed
 
 func _ready():
+	set_network_master(1)
 	get_tree().connect("connected_to_server", self, "_on_connected")
 	Network.connect("server_started", self, "_on_connected")
-
 
 func transition(new_state) -> bool:
 	print("attempting to transition gamestate from ", state, " to ", new_state)
@@ -24,10 +24,24 @@ func transition(new_state) -> bool:
 		var old_state: int = state
 		state = new_state
 		emit_signal('state_changed', old_state, new_state)
+		rpc("receiveTransition", new_state)
 		print("transition successful")
 		return true
 	print("transition failed")
 	return false
+
+puppet func receiveTransition(new_state):
+	if get_tree().is_network_server():
+		return
+	print("attempting to transition gamestate from ", state, " to ", new_state)
+	if (TRANSITIONS[state].has(new_state)):
+		var old_state: int = state
+		state = new_state
+		emit_signal('state_changed', old_state, new_state)
+		print("transition successful")
+		return# true
+	print("transition failed")
+	return# false
 
 func get_state() -> int:
 	return state

--- a/src/assets/autoload/network.gd
+++ b/src/assets/autoload/network.gd
@@ -27,6 +27,7 @@ func client_server(port: int, playerName: String) -> void:
 	connection = Connection.CLIENT_SERVER
 	player_name = playerName
 	myID = 1
+	peers.append(1)
 	names[1] = player_name
 	print(names)
 	server = WebSocketServer.new()
@@ -115,11 +116,17 @@ func connect_signals() -> void:
 	get_tree().connect("connection_failed", self, "_connection_failed")
 	get_tree().connect("server_disconnected", self, "_server_disconnected")
 
+func get_my_id() -> int:
+	return myID
+
 func get_player_name(id: int = myID) -> String:
 	if names.keys().has(id):
 		return names[id]
 	else:
 		return player_name
+
+func get_peers() -> Array:
+	return peers
 
 func on_state_changed(old_state, new_state) -> void:
 	match new_state:

--- a/src/assets/autoload/playermanager.gd
+++ b/src/assets/autoload/playermanager.gd
@@ -6,3 +6,80 @@ extends Node
 var inMenu = false
 var isintruder = false
 var ournumber
+
+#vars for role assignment
+#Percent assigns based on what % should be x role, Amount assigns given amount to x role
+enum assignStyle {Percent, Amount}
+var style: int = assignStyle.Percent
+var enabledRoles: Array = ["traitor", "detective", "default"]
+var roles: Dictionary = {"traitor": {"percent": float(2)/7, "amount": 1, "critical": true}, 
+						"detective": {"percent": float(1)/7, "amount": 1, "critical": false}, 
+						"default": {"percent": 0, "amount": 0, "critical": false}}
+var playerRoles: Dictionary = {}
+
+signal roles_assigned
+
+func _ready():
+	set_network_master(1)
+	GameManager.connect("state_changed", self, "state_changed")
+
+func state_changed(old_state, new_state):
+	if new_state == GameManager.State.Normal:
+		assignRoles(Network.get_peers())
+
+func assignRoles(players: Array):
+	if not get_tree().is_network_server():
+		return
+	print("assigning roles")
+	playerRoles = {}
+	var toAssign = players.duplicate() #duplicating to avoid linking to external array
+	randomize() #randomizes seed
+	toAssign.shuffle()
+	#print(toAssign)
+	var playerAmount = toAssign.size()
+
+	#if using percent, find how many of each role to assign
+	if style == assignStyle.Percent:
+		for i in enabledRoles:
+			if not roles.keys().has(i) or i == "default":
+				break
+			#rounds down to be more predictable, if percent is 1/7th, role won't be assigned until there are 7 players
+			roles[i].amount = roundDown(roles[i].percent * playerAmount, 1)
+			if roles[i].amount < 1 and roles[i].critical:
+				roles[i].amount = 1
+
+	# of players that aren't going to be assigned to a special role
+	var defaults = playerAmount
+	for i in enabledRoles:
+		if not roles.keys().has(i) or i == "default":
+			break
+		defaults -= roles[i].amount
+	if defaults < 0:
+		defaults = 0
+	roles.default.amount = defaults
+	#print("roles: ", roles)
+
+	#actually assign roles
+	for i in enabledRoles:
+		if not roles.keys().has(i):
+			break
+		for x in roles[i].amount:
+			playerRoles[toAssign[0]] = i
+			toAssign.erase(toAssign[0])
+	print("roles assigned: ", playerRoles)
+	rpc("receiveRoles", playerRoles)
+	emit_signal("roles_assigned", playerRoles)
+
+puppet func receiveRoles(newRoles):
+	playerRoles = newRoles
+	print("received roles: ", newRoles)
+	emit_signal("roles_assigned", playerRoles)
+
+func roundDown(num, step):
+	var normRound = stepify(num, step)
+	if normRound > num:
+		return normRound - step
+	return normRound
+
+func get_player_roles() -> Dictionary:
+	return playerRoles

--- a/src/assets/main/Button.gd
+++ b/src/assets/main/Button.gd
@@ -1,18 +1,8 @@
 extends Button
 
-
-# Declare member variables here. Examples:
-# var a = 2
-# var b = "text"
-
-
-# Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
+	GameManager.connect("state_changed", self, "state_changed")
 
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta):
-#	pass
-func _on_Node2D_clientstartgame():
-	queue_free()
+func state_changed(old_state, new_state):
+	if new_state == GameManager.State.Normal:
+		queue_free()

--- a/src/assets/main/main.gd
+++ b/src/assets/main/main.gd
@@ -128,39 +128,8 @@ func _on_main_player_moved(position : Vector2, movement : Vector2):
 	else:
 		rpc("other_player_moved", 1, position, movement)
 
-signal clientstartgame
-#since this code can only be triggered when the server presses the start game button, we will put task assignment or role assignment here
+#since this code can only be triggered when the server presses the start game button, we will tell the FSM to change state
 func _on_startgamebutton_gamestartpressed():
 	print("game start triggered")
-	serverassign()
-	while intruders <= 2:
-		var rng = RandomNumberGenerator.new()
-		var isintruder = false
-		rng.randomize()
-		var my_random_number = rng.randi_range(0, Network.peers.size())
-		#technically should generate a 1 in 10 chance of you being an intruder
-		intruders = intruders + 1
-		rpc("startgame",my_random_number)
-		isintruder = false
 	# TODO: Looser coupling here would be nice
-	GameManager.state = GameManager.State.Normal
-
-remote func startgame(intrudernumber):
-	if intrudernumber == PlayerManager.ournumber:
-		print("we are the intruder!")
-		PlayerManager.isintruder = true
-	else:
-		print("we are not the intruder")
-	emit_signal("clientstartgame")
-
-func serverassign():
-	var rng = RandomNumberGenerator.new()
-	var isintruder = false
-	rng.randomize()
-	var my_random_number = rng.randf_range(0, Network.peers.size())
-	print(my_random_number)
-	if intruders <= 2 and my_random_number == 0:
-		print("host is the intruder!")
-		PlayerManager.isintruder = true
-	else:
-		print("we are not the intruder")
+	GameManager.transition(GameManager.State.Normal)

--- a/src/assets/main/main.tscn
+++ b/src/assets/main/main.tscn
@@ -76,7 +76,6 @@ script = ExtResource( 2 )
 
 [node name="test" parent="maps" instance=ExtResource( 6 )]
 light_mask = 2
-[connection signal="clientstartgame" from="." to="players/Player/Camera2D/CanvasLayer/Button" method="_on_Node2D_clientstartgame"]
 [connection signal="pressed" from="players/Player/Camera2D/CanvasLayer/Button" to="players/Player/Camera2D/CanvasLayer/chatbox" method="popup"]
 [connection signal="gamestartpressed" from="players/Player/Camera2D/CanvasLayer/startgamebutton" to="." method="_on_startgamebutton_gamestartpressed"]
 [connection signal="gamestartpressed" from="players/Player/Camera2D/CanvasLayer/startgamebutton" to="players/Player/Camera2D/CanvasLayer/Button" method="_on_startgamebutton_gamestartpressed"]

--- a/src/assets/player/player.gd
+++ b/src/assets/player/player.gd
@@ -7,6 +7,7 @@ export (int) var speed = 150
 # Set by main.gd. Is the client's unique id for this player
 var id: int
 var ourname: String
+var myRole: String
 var velocity = Vector2(0,0)
 # Contains the current intended movement direction and magnitude in range 0 to 1
 var movement = Vector2(0,0)
@@ -23,10 +24,26 @@ func _ready():
 		$VisibleArea.enabled = true
 		$Dark.enabled = true
 		setName(Network.get_player_name())
+	PlayerManager.connect("roles_assigned", self, "roles_assigned")
 
 func setName(newName):
 	ourname = newName
 	$Label.text = ourname
+
+func roles_assigned(playerRoles: Dictionary):
+	print("id: ", id)
+	if id == 0: #if id hasn't been set to anything
+		myRole = playerRoles[Network.get_my_id()]
+	else:
+		myRole = playerRoles[id]
+	changeNameColor(myRole)
+	pass
+
+func changeNameColor(role: String):
+	if role == "traitor":
+		$Label.set("custom_colors/font_color", Color(1,0,0))
+	if role == "detective":
+		$Label.set("custom_colors/font_color", Color(0,0,1))
 
 # Only called when main_player is true
 func get_input():

--- a/src/assets/player/player.tscn
+++ b/src/assets/player/player.tscn
@@ -32,14 +32,14 @@ animations = [ {
 "name": "walk-h",
 "speed": 5.0
 }, {
-"frames": [ ExtResource( 12 ), ExtResource( 11 ), ExtResource( 14 ), ExtResource( 13 ) ],
-"loop": true,
-"name": "walk-up",
-"speed": 8.0
-}, {
 "frames": [ ExtResource( 9 ), ExtResource( 7 ), ExtResource( 8 ), ExtResource( 10 ) ],
 "loop": true,
 "name": "walk-down",
+"speed": 8.0
+}, {
+"frames": [ ExtResource( 12 ), ExtResource( 11 ), ExtResource( 14 ), ExtResource( 13 ) ],
+"loop": true,
+"name": "walk-up",
 "speed": 8.0
 } ]
 
@@ -55,6 +55,7 @@ shape = SubResource( 1 )
 [node name="Sprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "walk-h"
+frame = 2
 playing = true
 
 [node name="Label" type="Label" parent="."]


### PR DESCRIPTION
The FSM in gamemanager.gd is now synced across the network. The role assigning system now allows an infinite number of roles and 2 options for how to assign roles (percent players x role or y players x role). Role assignment was moved out of main.gd and into playermanager.gd. I wasn't sure where to put role assignment, so I made sure it would be easy to cut and paste somewhere else.