### PR TITLE
Run the movement calculations on the server

### DIFF
--- a/src/assets/main/main.gd
+++ b/src/assets/main/main.gd
@@ -8,7 +8,7 @@ var player_scene = load(player_s)
 var players = {}
 #!!!THIS IS IMPORTANT!!!
 #INCREASE THIS VARIABLE BY ONE EVERY COMMIT TO PREVENT OLD CLIENTS FROM TRYING TO CONNECT TO SERVERS!!!
-var version = 8
+var version = 9
 var intruders = 0
 var newnumber
 
@@ -27,7 +27,6 @@ func _enter_tree():
 		get_tree().connect("network_peer_connected", self, "_player_connected")
 		get_tree().connect("network_peer_disconnected", self, "_player_disconnected")
 		Network.connect("connection_handled", self, "connection_handled")
-		players[1] = $players/Player
 		PlayerManager.ournumber = 0
 	elif Network.connection == Network.Connection.CLIENT:
 		get_tree().connect("network_peer_disconnected", self, "_player_disconnected")
@@ -35,6 +34,15 @@ func _enter_tree():
 		#var peer = NetworkedMultiplayerENet.new()
 		#peer.create_client(Network.host, Network.port)
 		#get_tree().network_peer = peer
+	players[get_tree().get_network_unique_id()] = $players/Player
+
+# Keep the clients' player positions updated
+func _physics_process(delta):
+	if get_tree().is_network_server():
+		var positions_dict = {}
+		for id in players.keys():
+			positions_dict[id] = [players[id].position, players[id].movement]
+		rpc("update_positions", positions_dict)
 
 func connection_handled(id, playerName):
 	print("connection handled, id: ", id, " name: ", playerName)
@@ -86,36 +94,27 @@ puppet func createPlayer(id, playerName):
 	newPlayer.setName(playerName)
 	print("New player: ", id)
 
-# Called from client sides when a player moves
-remote func player_moved(new_pos, new_movement):
+# Called from client side to tell the server about the player's actions
+remote func player_moved(new_movement):
 	# Should only be run on the server
 	if !get_tree().is_network_server():
 		return
 	var id = get_tree().get_rpc_sender_id()
 	#print(id)
 	#print("Got player move from ", id) #no reason to spam console so much
-	# Check movement validity here
 	if not players.keys().has(id):
 		return
-	players[id].move_to(new_pos, new_movement)
-	# The move_to function validates new_x, new_y,
-	# so that's why we don't reuse them
-	new_pos = players[id].position
-	for other_id in players:
-		if id != other_id && other_id != 1:
-			#print("Sending player moved to client ", other_id) #no reason to spam console so much
-			rpc_id(other_id, "other_player_moved", id, new_pos, new_movement)
+	# Check movement validity
+	if new_movement.length() > 1:
+		new_movement = new_movement.normalized()
+	players[id].movement = new_movement
 
-# Called from server when other players move
-puppet func other_player_moved(id, new_pos, new_movement):
-	#print("Moving ", id, " to ", new_pos.x, ", ", new_pos.y) #no reason to spam console so much
-	if players.keys().has(id):
-		players[id].move_to(new_pos, new_movement)
+# Called from server when the server's players move
+puppet func update_positions(positions_dict):
+	for id in positions_dict.keys():
+		if players.keys().has(id):
+			players[id].move_to(positions_dict[id][0], positions_dict[id][1])
 
-func _on_main_player_moved(position : Vector2, movement : Vector2):
-	#In the beginning Godot created the heaven and the earth
-	#about 100% of the fix for the "host invisible" bug
+func _on_main_player_moved(movement : Vector2):
 	if not get_tree().is_network_server():
-		rpc_id(1, "player_moved", position, movement)
-	else:
-		rpc("other_player_moved", 1, position, movement)
+		rpc_id(1, "player_moved", movement)

--- a/src/assets/player/player.gd
+++ b/src/assets/player/player.gd
@@ -63,23 +63,20 @@ func get_input():
 		movement.x = Input.get_action_strength('ui_right') - Input.get_action_strength('ui_left')
 		movement.y = Input.get_action_strength('ui_down') - Input.get_action_strength('ui_up')
 		movement = movement.normalized()
-		#we did it boys, micheal jackson is no more
-#		$Sprite.play("walk-up") for some reason having this makes it not work
-
-	velocity = movement * speed
-
-	#interpolate velocity:
-	if velocity.x == 0:
-		velocity.x = lerp(prev_velocity.x, 0, 0.17)
-	if velocity.y == 0:
-		velocity.y = lerp(prev_velocity.y, 0, 0.17)
 
 func _physics_process(delta):
 	if main_player:
 		get_input()
+		emit_signal("main_player_moved", movement)
+	if get_tree().is_network_server():
+		var prev_velocity = velocity
+		velocity = movement * speed
+		#interpolate velocity:
+		if velocity.x == 0:
+			velocity.x = lerp(prev_velocity.x, 0, 0.17)
+		if velocity.y == 0:
+			velocity.y = lerp(prev_velocity.y, 0, 0.17)
 		velocity = move_and_slide(velocity)
-		emit_signal("main_player_moved", position, movement)
-
 	# We handle animations and stuff here
 	if movement.x > x_anim_margin:
 		$Sprite.play("walk-h")
@@ -95,6 +92,5 @@ func _physics_process(delta):
 		$Sprite.play("idle")
 
 func move_to(new_pos, new_movement):
-	# Movement check here
 	position = new_pos
 	movement = new_movement


### PR DESCRIPTION
This implementation has some problems that need to be fixed later:
* The clients receive a position update 60 times per second. The rate should be lower and the clients should interpolate between the states
* The clients send an action update 60 times per second. The rate should be lower, but implementing it properly can be difficult
* The player movements are very drifty on slow networks because there is no client-side prediction

![video of laggy movement](https://user-images.githubusercontent.com/16741932/98258121-282dc180-1f89-11eb-8c26-51456b5f38fd.gif)
laggy movement (100ms ping)