### PR TITLE
Implement simple client-side prediction

### DIFF
--- a/src/assets/player/player.gd
+++ b/src/assets/player/player.gd
@@ -17,6 +17,16 @@ export var main_player = false
 var x_anim_margin = 0.1
 var y_anim_margin = 0.1
 
+# The input number is incremented on each _physics_process call. GDScript's int
+# type is int64_t which is enough for thousands of years of gameplay
+var input_number: int = 0
+# Contains the last input number that the server has received
+var last_reveived_input: int = 0
+# Contains the movement values for unreceived inputs and matching previous
+# velocities for movement prediciton. The values are stored as Arrays of
+# movement and previous velocity.
+var input_queue: Array = []
+
 func _ready():
 	if "--server" in OS.get_cmdline_args():
 		main_player = false
@@ -58,27 +68,33 @@ func setNameColor(newColor: Color):
 
 # Only called when main_player is true
 func get_input():
-# warning-ignore:unused_variable
-	var prev_velocity = velocity
 	movement = Vector2(0, 0)
 	if not UIManager.in_menu():
 		movement.x = Input.get_action_strength('ui_right') - Input.get_action_strength('ui_left')
 		movement.y = Input.get_action_strength('ui_down') - Input.get_action_strength('ui_up')
 		movement = movement.normalized()
 
+func run_physics(motion):
+	var prev_velocity = velocity
+	velocity = motion * speed
+	#interpolate velocity:
+	if velocity.x == 0:
+		velocity.x = lerp(prev_velocity.x, 0, 0.17)
+	if velocity.y == 0:
+		velocity.y = lerp(prev_velocity.y, 0, 0.17)
+	# TODO: provide a delta value to this function and use it here
+	velocity = move_and_slide(velocity)
+
 func _physics_process(_delta):
 	if main_player:
 		get_input()
-		emit_signal("main_player_moved", movement)
-	if get_tree().is_network_server():
-		var prev_velocity = velocity
-		velocity = movement * speed
-		#interpolate velocity:
-		if velocity.x == 0:
-			velocity.x = lerp(prev_velocity.x, 0, 0.17)
-		if velocity.y == 0:
-			velocity.y = lerp(prev_velocity.y, 0, 0.17)
-		velocity = move_and_slide(velocity)
+		input_number += 1
+		input_queue.push_back([movement, velocity])
+		emit_signal("main_player_moved", movement, input_number)
+	# Remove this if check to get bad movement extrapolation for all players
+	if main_player or get_tree().is_network_server():
+		run_physics(movement)
+
 	# We handle animations and stuff here
 	if movement.x > x_anim_margin:
 		$Sprite.play("walk-h")
@@ -92,6 +108,23 @@ func _physics_process(_delta):
 		$Sprite.play("walk-up")
 	else:
 		$Sprite.play("idle")
+
+# Only called on the main player. Rerolls the player's unreceived inputs on top
+# of the server's player position
+func _on_positions_updated(new_last_received_input: int):
+	if new_last_received_input > input_number:
+		# The map has probably changed when this happens
+		return
+	# Remove received inputs from the queue
+	for _i in range(new_last_received_input - last_reveived_input):
+		input_queue.pop_front()
+	last_reveived_input = new_last_received_input
+	# Set the initial velocity to predict velocity slowdown correctly
+	if input_queue.size() >= 1:
+		velocity = input_queue[0][1]
+	# Run the physics model for the unreceived inputs
+	for i in input_queue:
+		run_physics(i[0])
 
 func move_to(new_pos, new_movement):
 	position = new_pos


### PR DESCRIPTION
The client stores the unreceived inputs in a queue and executes them on top of the server's player position. Current problems:
- The players can jump a bit because of a mismatch between local state and server state. It can occur for example because of unstable ping. The position update rate should be lower to allow implementing soft interpolation
- Client-side prediction doesn't work correctly if _physics_process isn't called at a constant rate.

You can add a delay on loopback/localhost on Linux by running `tc qdisc add dev lo root netem delay 100ms` as root (run `tc qdisc del dev lo root netem delay 100ms` to remove the delay).