### PR TITLE
Send player position updates at a lower rate

### DIFF
--- a/src/assets/main/main.gd
+++ b/src/assets/main/main.gd
@@ -37,7 +37,7 @@ func _enter_tree() -> void:
 		get_tree().connect("network_peer_disconnected", self, "_player_disconnected")
 
 # Keep the clients' player positions updated
-func _physics_process(_delta: float) -> void:
+func _on_NetworkUpdateTimer_timeout() -> void:
 	if get_tree().is_network_server():
 		var positions_dict = {}
 		for id in players.keys():

--- a/src/assets/main/main.tscn
+++ b/src/assets/main/main.tscn
@@ -16,4 +16,10 @@ color = Color( 0.188235, 0.164706, 0.164706, 1 )
 
 [node name="maps" type="YSort" parent="."]
 script = ExtResource( 2 )
+
+[node name="NetworkUpdateTimer" type="Timer" parent="."]
+process_mode = 0
+wait_time = 0.1
+autostart = true
 [connection signal="spawn" from="maps" to="." method="_on_maps_spawn"]
+[connection signal="timeout" from="NetworkUpdateTimer" to="." method="_on_NetworkUpdateTimer_timeout"]

--- a/src/assets/player/player.gd
+++ b/src/assets/player/player.gd
@@ -178,8 +178,12 @@ func _on_positions_updated(new_last_received_input: int):
 		run_physics(i[0])
 
 func move_to(new_pos, new_movement):
-	position = new_pos
 	movement = new_movement
+	if main_player:
+		position = new_pos
+	else:
+		$Tween.interpolate_property(self, "position", null, new_pos, 0.1)
+		$Tween.start()
 
 func get_is_alive() -> bool:
 	return not death_handler.is_dead

--- a/src/assets/player/player.tscn
+++ b/src/assets/player/player.tscn
@@ -141,5 +141,7 @@ script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": "Handles being killed by infiltrators."
 }
+
+[node name="Tween" type="Tween" parent="."]
 [connection signal="body_entered" from="interactarea" to="interactarea" method="_on_interactarea_body_entered"]
 [connection signal="body_exited" from="interactarea" to="interactarea" method="_on_interactarea_body_exited"]


### PR DESCRIPTION
Current problems:
- Main player position isn't corrected smoothly because I'm not sure how to implement that
- Players slide to spawns because spawning isn't separated from normal movement