### PR TITLE
Items pick and drop functionality

### DIFF
--- a/src/assets/maps/common/interactables/items/icons/item0.png
+++ b/src/assets/maps/common/interactables/items/icons/item0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4aeedf9346ca6dd99a933b8e2d459fe7f65fd7b16ffd96eb197db026cd51ca60
+size 521

--- a/src/assets/maps/common/interactables/items/icons/item0.png.import
+++ b/src/assets/maps/common/interactables/items/icons/item0.png.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/item0.png-02845302d52b7d98ffb98bec8022d05e.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://assets/maps/common/interactables/items/icons/item0.png"
+dest_files=[ "res://.import/item0.png-02845302d52b7d98ffb98bec8022d05e.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/src/assets/maps/common/interactables/items/item.gd
+++ b/src/assets/maps/common/interactables/items/item.gd
@@ -1,0 +1,29 @@
+extends RigidBody2D
+
+var pick = false
+var prop
+var for_tra=Vector2(0, 0)
+var mov_speed =0.3
+
+func _ready():
+	pass 
+
+func _process(delta):
+	if pick == false:
+		prop = get_node("Sprite")
+		prop.translate(for_tra)
+	else:
+		return
+		
+
+func texture(texture:String):
+	#TODO:Set texture for item
+	var to_set = load(texture)
+	get_node("Sprite").set_texture(to_set)
+
+func _on_Timer_timeout():
+	if for_tra == Vector2(0,-mov_speed):
+		for_tra = Vector2(0, mov_speed)
+	else:
+		for_tra = Vector2(0, -mov_speed)
+

--- a/src/assets/maps/common/interactables/items/item.tscn
+++ b/src/assets/maps/common/interactables/items/item.tscn
@@ -1,0 +1,26 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://assets/maps/common/interactables/items/item.gd" type="Script" id=1]
+[ext_resource path="res://assets/maps/common/interactables/items/icons/item0.png" type="Texture" id=2]
+
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 8, 8 )
+
+[node name="item" type="RigidBody2D"]
+z_index = 5
+input_pickable = true
+collision_layer = 1024
+collision_mask = 2048
+gravity_scale = 0.0
+script = ExtResource( 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 1 )
+
+[node name="Sprite" type="Sprite" parent="."]
+texture = ExtResource( 2 )
+
+[node name="Timer" type="Timer" parent="Sprite"]
+wait_time = 1.5
+autostart = true
+[connection signal="timeout" from="Sprite/Timer" to="." method="_on_Timer_timeout"]

--- a/src/assets/maps/test/test.tscn
+++ b/src/assets/maps/test/test.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=32 format=2]
+[gd_scene load_steps=33 format=2]
 
 [ext_resource path="res://assets/common/textures/icons/spawnpad.png" type="Texture" id=1]
 [ext_resource path="res://assets/maps/common/dynamic/testdoor/testdoor.tscn" type="PackedScene" id=2]
@@ -11,6 +11,7 @@
 [ext_resource path="res://addons/opensusinteraction/resources/interact/interact.gd" type="Script" id=9]
 [ext_resource path="res://addons/opensusinteraction/resources/interactmap/interactmap.gd" type="Script" id=10]
 [ext_resource path="res://addons/opensusinteraction/resources/interactui/interactui.gd" type="Script" id=11]
+[ext_resource path="res://assets/maps/common/interactables/items/item.tscn" type="PackedScene" id=12]
 
 [sub_resource type="Resource" id=1]
 resource_local_to_scene = true
@@ -391,3 +392,9 @@ position = Vector2( 600, 0 )
 scale = Vector2( 3, 19 )
 
 [node name="Corpses" type="YSort" parent="."]
+
+[node name="item" parent="." instance=ExtResource( 12 )]
+position = Vector2( -168, 40 )
+
+[node name="item2" parent="." instance=ExtResource( 12 )]
+position = Vector2( 184, 64 )

--- a/src/assets/player/player.tscn
+++ b/src/assets/player/player.tscn
@@ -1,32 +1,40 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://assets/player/player.gd" type="Script" id=1]
 [ext_resource path="res://assets/player/skeleton.tscn" type="PackedScene" id=2]
 [ext_resource path="res://assets/player/death_handler.gd" type="Script" id=3]
+[ext_resource path="res://assets/common/shaders/skin_color_key.shader" type="Shader" id=4]
 [ext_resource path="res://assets/player/textures/light.png" type="Texture" id=15]
 [ext_resource path="res://assets/player/interactarea.gd" type="Script" id=16]
 [ext_resource path="res://assets/common/shaders/player.shader" type="Shader" id=17]
 [ext_resource path="res://assets/player/camera.gd" type="Script" id=27]
 
-[sub_resource type="CircleShape2D" id=3]
+[sub_resource type="CircleShape2D" id=1]
 radius = 100.0
+
+[sub_resource type="CanvasItemMaterial" id=2]
+light_mode = 2
+
+[sub_resource type="CapsuleShape2D" id=3]
+radius = 12.0
 
 [sub_resource type="CanvasItemMaterial" id=4]
 light_mode = 2
 
-[sub_resource type="CapsuleShape2D" id=5]
-radius = 12.0
+[sub_resource type="ShaderMaterial" id=5]
+resource_local_to_scene = true
+shader = ExtResource( 4 )
+shader_param/skin_mask_color = Color( 1, 0, 1, 1 )
+shader_param/skin_color = Color( 0.827451, 0.705882, 0.580392, 1 )
+shader_param/tolerance = 0.75
 
-[sub_resource type="CanvasItemMaterial" id=6]
-light_mode = 2
-
-[sub_resource type="ShaderMaterial" id=7]
+[sub_resource type="ShaderMaterial" id=6]
 resource_local_to_scene = true
 shader = ExtResource( 17 )
 shader_param/line_color = Color( 1, 1, 1, 0 )
 shader_param/line_thickness = 5.0
 
-[sub_resource type="ViewportTexture" id=8]
+[sub_resource type="ViewportTexture" id=7]
 viewport_path = NodePath("SpritesViewport")
 
 [node name="Player" type="KinematicBody2D" groups=[
@@ -50,12 +58,12 @@ enabled = true
 collision_mask = 17
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="interactarea"]
-shape = SubResource( 3 )
+shape = SubResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-material = SubResource( 4 )
+material = SubResource( 2 )
 rotation = 1.5708
-shape = SubResource( 5 )
+shape = SubResource( 3 )
 
 [node name="MainLight" type="Light2D" parent="."]
 position = Vector2( -0.37458, -0.226169 )
@@ -77,7 +85,7 @@ drag_margin_bottom = 0.65
 script = ExtResource( 27 )
 
 [node name="Label" type="Label" parent="."]
-material = SubResource( 6 )
+material = SubResource( 4 )
 margin_left = -250.0
 margin_top = -75.0
 margin_right = 250.0
@@ -89,6 +97,7 @@ __meta__ = {
 }
 
 [node name="Skeleton" parent="." instance=ExtResource( 2 )]
+material = SubResource( 5 )
 use_parent_material = true
 
 [node name="SpritesViewport" type="Viewport" parent="."]
@@ -119,10 +128,10 @@ __meta__ = {
 }
 
 [node name="ViewportTextureTarget" type="Sprite" parent="."]
-material = SubResource( 7 )
+material = SubResource( 6 )
 position = Vector2( 0, -20 )
 scale = Vector2( 0.25, 0.25 )
-texture = SubResource( 8 )
+texture = SubResource( 7 )
 __meta__ = {
 "_editor_description_": "The Sprite that the viewport tex ture of SpritesViewport will be rendered to."
 }
@@ -132,5 +141,13 @@ script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": "Handles being killed by infiltrators."
 }
+
+[node name="reach" type="RayCast2D" parent="."]
+enabled = true
+cast_to = Vector2( 30, 30 )
+collision_mask = 1024
+
+[node name="hand_pos" type="Position2D" parent="reach"]
+position = Vector2( -5.92957, -8.9638 )
 [connection signal="body_entered" from="interactarea" to="interactarea" method="_on_interactarea_body_entered"]
 [connection signal="body_exited" from="interactarea" to="interactarea" method="_on_interactarea_body_exited"]

--- a/src/project.godot
+++ b/src/project.godot
@@ -131,6 +131,16 @@ reload={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":82,"unicode":0,"echo":false,"script":null)
  ]
 }
+ui_pick={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":80,"unicode":0,"echo":false,"script":null)
+ ]
+}
+ui_drop={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":81,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [input_devices]
 
@@ -148,6 +158,10 @@ pointing/emulate_touch_from_mouse=true
 
 translations=PoolStringArray( "res://locale/de.po", "res://locale/el.po", "res://locale/en.po", "res://locale/es.po", "res://locale/fr.po", "res://locale/hu.po", "res://locale/ko.po", "res://locale/ro.po", "res://locale/sr.po", "res://locale/sv.po" )
 locale_filter=[ 0, [  ] ]
+
+[network]
+
+limits/debugger_stdout/max_chars_per_second=100000000000
 
 [rendering]
 


### PR DESCRIPTION
This PR gives the player ability to pick and drop items 

**Features:**

- Player can pick items and drop it and this sync over network

- If the item is picked by an infiltrator killing is disabled

- Items will hover in air when not picked

**This pr doesn't include:-**

- Items related to tasks

- Yellow shader over the items when get close to it

- Any type of asset(It have just a small box as placeholder for item prop )

The map already contained some instanced scene of items so when it get reviewed i will remove them at last
It also doesn't any include good comments :( but if it stays here for long i will push them
Please also refer to pr #246  and merge the best one.
