### PR TITLE
Add a base UI class for control nodes

### DIFF
--- a/src/assets/common/classes/ui/base/controlbase.gd
+++ b/src/assets/common/classes/ui/base/controlbase.gd
@@ -1,0 +1,26 @@
+extends Control
+
+class_name ControlBase
+
+export (String) var menu_name
+
+export (bool) var disable_movement
+
+func _init():
+	connect("visibility_changed", self, "_on_visibility_changed")
+
+#called by ui system
+func base_open():
+	show()
+
+#called by self or ui system
+func base_close():
+	hide()
+
+func _on_visibility_changed():
+	if not disable_movement:
+		return
+	if visible:
+		UIManager.ui_opened(menu_name)
+	else:
+		UIManager.ui_closed(menu_name)

--- a/src/assets/common/classes/ui/base/popupbase.gd
+++ b/src/assets/common/classes/ui/base/popupbase.gd
@@ -4,6 +4,8 @@ class_name PopupBase
 
 export (String) var menu_name
 
+export (bool) var disable_movement
+
 #called by ui system
 func base_open():
 	popup()
@@ -14,6 +16,8 @@ func base_close():
 
 # warning-ignore:unused_argument
 func _notification(what):
+	if not disable_movement:
+		return
 	match what:
 		NOTIFICATION_POST_POPUP:
 			UIManager.ui_opened(menu_name)

--- a/src/assets/common/classes/ui/base/popuppanelbase.gd
+++ b/src/assets/common/classes/ui/base/popuppanelbase.gd
@@ -4,6 +4,8 @@ class_name PopupPanelBase
 
 export (String) var menu_name
 
+export (bool) var disable_movement
+
 #called by ui system
 func base_open():
 	popup()
@@ -14,6 +16,8 @@ func base_close():
 
 # warning-ignore:unused_argument
 func _notification(what):
+	if not disable_movement:
+		return
 	match what:
 		NOTIFICATION_POST_POPUP:
 			UIManager.ui_opened(menu_name)

--- a/src/assets/common/classes/ui/base/windowdialogbase.gd
+++ b/src/assets/common/classes/ui/base/windowdialogbase.gd
@@ -4,6 +4,8 @@ class_name WindowDialogBase
 
 export (String) var menu_name
 
+export (bool) var disable_movement
+
 #called by ui system
 func base_open():
 	popup()
@@ -14,6 +16,8 @@ func base_close():
 
 # warning-ignore:unused_argument
 func _notification(what):
+	if not disable_movement:
+		return
 	match what:
 		NOTIFICATION_POST_POPUP:
 			UIManager.ui_opened(menu_name)

--- a/src/assets/common/classes/ui/task/controltask.gd
+++ b/src/assets/common/classes/ui/task/controltask.gd
@@ -1,0 +1,13 @@
+extends ControlBase
+
+class_name ControlTask
+
+#called by ui system
+func base_open():
+	#call base_open() in parent class
+	.base_open()
+
+#called by self or ui system
+func base_close():
+	#call base_close() in parent class
+	.base_close()

--- a/src/assets/ui/hud/infiltrator_hud/infiltrator_hud.gd
+++ b/src/assets/ui/hud/infiltrator_hud/infiltrator_hud.gd
@@ -1,4 +1,4 @@
-extends Control
+extends ControlBase
 
 # Animator for infiltrator-specific animations
 onready var animator: AnimationPlayer
@@ -35,10 +35,6 @@ func _process(_delta: float) -> void:
 		if animator != null and animator.current_animation == "Reload":
 			progress = animator.current_animation_position / animator.current_animation_length
 		reload_button.material.set_shader_param("progress", progress)
-
-func base_open() -> void:
-	"""For sake of compliance with open_menu."""
-	pass
 
 func _on_Infiltrator_Animator_animation_finished(anim_name: String) -> void:
 	"""

--- a/src/assets/ui/hud/infiltrator_hud/infiltrator_hud.tscn
+++ b/src/assets/ui/hud/infiltrator_hud/infiltrator_hud.tscn
@@ -28,6 +28,7 @@ __meta__ = {
 "_edit_use_anchors_": false,
 "_editor_description_": "GUI that indicates whether a kill is ready to be executed."
 }
+menu_name = "killui"
 
 [node name="KillButton" type="TextureButton" parent="."]
 anchor_right = 1.0

--- a/src/assets/ui/hud/interactui/interactui.gd
+++ b/src/assets/ui/hud/interactui/interactui.gd
@@ -1,4 +1,4 @@
-extends Control
+extends ControlBase
 
 var buttonInteractDict: Dictionary = {}
 

--- a/src/assets/ui/hud/interactui/interactui.tscn
+++ b/src/assets/ui/hud/interactui/interactui.tscn
@@ -10,6 +10,7 @@ script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+menu_name = "interactui"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 anchor_top = 1.0

--- a/src/assets/ui/lobbyui/chatbox/chatbox.tscn
+++ b/src/assets/ui/lobbyui/chatbox/chatbox.tscn
@@ -13,6 +13,8 @@ theme = ExtResource( 2 )
 window_title = "Chatbox"
 resizable = true
 script = ExtResource( 1 )
+menu_name = "chatbox"
+disable_movement = true
 
 [node name="Control" type="Control" parent="."]
 anchor_right = 1.0

--- a/src/assets/ui/pausemenu/pausemenu.gd
+++ b/src/assets/ui/pausemenu/pausemenu.gd
@@ -1,4 +1,4 @@
-extends Control
+extends ControlBase
 
 func _ready():
 	pass
@@ -21,13 +21,6 @@ func show_only(node_name: String):
 	for i in get_children():
 		i.hide()
 	get_node(node_name).show()
-
-func _on_pausemenu_about_to_show():
-	pass
-
-func _on_pausemenu_popup_hide():
-	pass
-#	close()
 
 func _on_resume_pressed():
 	_resume_game()
@@ -53,7 +46,6 @@ func _on_quit_pressed():
 
 func _resume_game() -> void:
 	UIManager.close_ui("pausemenu")
-	UIManager.ui_closed("pausemenu")
 
 func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel") and visible and UIManager.current_ui == self:

--- a/src/assets/ui/pausemenu/pausemenu.tscn
+++ b/src/assets/ui/pausemenu/pausemenu.tscn
@@ -13,6 +13,8 @@ script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+menu_name = "pausemenu"
+disable_movement = true
 
 [node name="menu" type="CenterContainer" parent="."]
 anchor_left = 0.5

--- a/src/assets/ui/submenus/appearance_editor/appearance_editor.gd
+++ b/src/assets/ui/submenus/appearance_editor/appearance_editor.gd
@@ -1,4 +1,4 @@
-extends Control
+extends ControlBase
 
 # Controls for changing parts
 onready var part_selector_scene: PackedScene = preload("res://assets/ui/submenus/appearance_editor/part_selector.tscn")
@@ -241,7 +241,6 @@ func _close_editor() -> void:
 		close()
 	else:
 		UIManager.close_ui("appearance_editor")
-		UIManager.ui_closed("appearance_editor")
 
 func _on_SkinColorSelector_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT:

--- a/src/assets/ui/submenus/appearance_editor/appearance_editor.tscn
+++ b/src/assets/ui/submenus/appearance_editor/appearance_editor.tscn
@@ -54,14 +54,14 @@ colors = PoolColorArray( 0.984314, 0.968627, 0.898039, 1, 0.827451, 0.294118, 0.
 [sub_resource type="GradientTexture" id=10]
 gradient = SubResource( 9 )
 
-[sub_resource type="ShaderMaterial" id=12]
+[sub_resource type="ShaderMaterial" id=11]
 resource_local_to_scene = true
 shader = ExtResource( 6 )
 shader_param/skin_mask_color = Color( 1, 0, 1, 1 )
 shader_param/skin_color = Color( 0.827451, 0.705882, 0.580392, 1 )
 shader_param/tolerance = 0.75
 
-[sub_resource type="AnimationNodeStateMachinePlayback" id=11]
+[sub_resource type="AnimationNodeStateMachinePlayback" id=12]
 
 [node name="AppearanceEditor" type="Control"]
 anchor_right = 1.0
@@ -74,6 +74,8 @@ script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+menu_name = "appearance_editor"
+disable_movement = true
 
 [node name="Background" type="TextureRect" parent="."]
 anchor_right = 1.0
@@ -185,7 +187,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Skeleton" parent="MarginContainer/AppearanceHBox/PreviewButtonsVBox/PlayerContainer" instance=ExtResource( 5 )]
-material = SubResource( 12 )
+material = SubResource( 11 )
 position = Vector2( 223, 335 )
 scale = Vector2( 5, 5 )
 
@@ -194,7 +196,7 @@ playback_default_blend_time = 0.0
 
 [node name="AnimationTree" parent="MarginContainer/AppearanceHBox/PreviewButtonsVBox/PlayerContainer/Skeleton/AnimationPlayer" index="0"]
 active = false
-parameters/playback = SubResource( 11 )
+parameters/playback = SubResource( 12 )
 
 [node name="ButtonsHBox" type="HBoxContainer" parent="MarginContainer/AppearanceHBox/PreviewButtonsVBox"]
 margin_top = 438.0

--- a/src/assets/ui/tasks/clockset/clockset.tscn
+++ b/src/assets/ui/tasks/clockset/clockset.tscn
@@ -14,6 +14,8 @@ script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+menu_name = "clockset"
+disable_movement = true
 
 [node name="clock" type="HBoxContainer" parent="."]
 anchor_right = 1.0

--- a/src/project.godot
+++ b/src/project.godot
@@ -14,6 +14,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://assets/common/classes/ui/base/controlbase.gd"
 }, {
+"base": "ControlBase",
+"class": "ControlTask",
+"language": "GDScript",
+"path": "res://assets/common/classes/ui/task/controltask.gd"
+}, {
 "base": "Popup",
 "class": "PopupBase",
 "language": "GDScript",
@@ -46,6 +51,7 @@ _global_script_classes=[ {
 } ]
 _global_script_class_icons={
 "ControlBase": "",
+"ControlTask": "",
 "PopupBase": "",
 "PopupPanelBase": "",
 "PopupPanelTask": "",

--- a/src/project.godot
+++ b/src/project.godot
@@ -9,6 +9,11 @@
 config_version=4
 
 _global_script_classes=[ {
+"base": "Control",
+"class": "ControlBase",
+"language": "GDScript",
+"path": "res://assets/common/classes/ui/base/controlbase.gd"
+}, {
 "base": "Popup",
 "class": "PopupBase",
 "language": "GDScript",
@@ -40,6 +45,7 @@ _global_script_classes=[ {
 "path": "res://assets/common/classes/ui/task/windowdialogtask.gd"
 } ]
 _global_script_class_icons={
+"ControlBase": "",
 "PopupBase": "",
 "PopupPanelBase": "",
 "PopupPanelTask": "",


### PR DESCRIPTION
This creates a base class to use when creating UI elements with a control node as the root. It also adds a toggle for the UI to block movement.

Current UIs with a Control node as the root have been updated.