### PR TITLE
State changed priority signals

### DIFF
--- a/src/assets/autoload/gamemanager.gd
+++ b/src/assets/autoload/gamemanager.gd
@@ -9,9 +9,12 @@ const TRANSITIONS = {
 	State.Normal: [State.Lobby, State.Start],
 }
 
+var priority_amount: int = 6
+
 #signals that help sync the gamestate
 #can be connected to from anywhere with GameManager.connect("<signal name>", self, "<function name>")
-signal state_changed
+signal state_changed(old_state, new_state)
+signal state_changed_priority(old_state, new_state, priority)
 
 func _ready():
 	set_network_master(1)
@@ -20,31 +23,37 @@ func _ready():
 # warning-ignore:return_value_discarded
 	Network.connect("server_started", self, "_on_connected")
 
-func transition(new_state) -> bool:
+func transition(new_state: int) -> bool:
 	print("attempting to transition gamestate from ", state, " to ", new_state)
 	if (TRANSITIONS[state].has(new_state)):
 		var old_state: int = state
 		state = new_state
 		if get_tree().is_network_server():
-			rpc("receiveTransition", new_state)
-		emit_signal('state_changed', old_state, new_state)
+			rpc("receive_transition", new_state)
+		emit_state_changed_signals(old_state, new_state)
 		print("transition successful")
 		return true
 	print("transition failed")
 	return false
 
-puppet func receiveTransition(new_state):
+puppet func receive_transition(new_state: int):
 	if get_tree().is_network_server():
 		return
 	print("attempting to transition gamestate from ", state, " to ", new_state)
 	if (TRANSITIONS[state].has(new_state)):
 		var old_state: int = state
 		state = new_state
-		emit_signal('state_changed', old_state, new_state)
+		emit_state_changed_signals(old_state, new_state)
 		print("transition successful")
 		return# true
 	print("transition failed")
 	return# false
+
+func emit_state_changed_signals(old_state: int, new_state: int):
+	# emit state_changed_priority, priority starts at 0
+	for priority in priority_amount:
+		emit_signal("state_changed_priority", old_state, new_state, priority)
+	emit_signal('state_changed', old_state, new_state)
 
 func get_state() -> int:
 	return state

--- a/src/assets/autoload/network.gd
+++ b/src/assets/autoload/network.gd
@@ -21,7 +21,7 @@ func _ready() -> void:
 	# give the server access to puppet functions and variables
 	set_network_master(1)
 # warning-ignore:return_value_discarded
-	GameManager.connect('state_changed', self, '_on_state_changed')
+	GameManager.connect("state_changed_priority", self, "_on_state_changed_priority")
 
 func client_server(port: int, playerName: String) -> void:
 	print("Starting server on port ", port, " with host player name ", playerName)
@@ -172,7 +172,9 @@ func get_peers() -> Array:
 	return peers
 
 # warning-ignore:unused_argument
-func _on_state_changed(old_state, new_state) -> void:
+func _on_state_changed_priority(old_state: int, new_state: int, priority: int) -> void:
+	if priority != 0:
+		return
 	match new_state:
 		GameManager.State.Normal:
 			print('Network manager refusing further connections')

--- a/src/assets/autoload/playermanager.gd
+++ b/src/assets/autoload/playermanager.gd
@@ -32,7 +32,7 @@ signal roles_assigned
 func _ready():
 	set_network_master(1)
 # warning-ignore:return_value_discarded
-	GameManager.connect("state_changed", self, "state_changed")
+	GameManager.connect("state_changed_priority", self, "state_changed_priority")
 
 func assigntasks():
 	for id in Network.peers:
@@ -54,7 +54,9 @@ remote func gettasks(tasksget):
 	print("we got our tasks!")
 
 # warning-ignore:unused_argument
-func state_changed(old_state, new_state):
+func state_changed_priority(old_state: int, new_state: int, priority: int):
+	if priority != 2:
+		return
 	match new_state:
 		GameManager.State.Normal:
 			assignRoles(Network.get_peers())

--- a/src/assets/autoload/scenemanager.gd
+++ b/src/assets/autoload/scenemanager.gd
@@ -5,9 +5,11 @@ signal scene_changed #TODO: actually emit this signal
 
 func _ready() -> void:
 # warning-ignore:return_value_discarded
-	GameManager.connect('state_changed', self, '_on_gamestate_change')
+	GameManager.connect("state_changed_priority", self, "_on_state_changed_priority")
 	
-func _on_gamestate_change(old_state, new_state) -> void:
+func _on_state_changed_priority(old_state: int, new_state: int, priority: int) -> void:
+	if priority != 0:
+		return
 	if new_state == GameManager.State.Lobby:
 		if old_state == GameManager.State.Normal:
 			return

--- a/src/assets/main/main.gd
+++ b/src/assets/main/main.gd
@@ -15,11 +15,13 @@ var intruders = 0
 var newnumber
 var spawn_pos = Vector2(0,0)
 var player_data_dict: Dictionary
+var player_spawn_points: Dictionary
 
 signal positions_updated(last_received_input)
 
 func _ready() -> void:
 	set_network_master(1)
+	GameManager.connect("state_changed_priority", self, "state_changed_priority")
 
 # Gets called when the title scene sets this scene as the main scene
 func _enter_tree() -> void:
@@ -167,8 +169,15 @@ master func _on_maps_spawn(spawnPositions: Array):
 		spawnPointDict[players.keys()[i]] = spawnPositions[i % spawnPositions.size()]
 		if spawnPointDict[players.keys()[i]] == null:
 			spawnPointDict[players.keys()[i]] = spawn_pos
+	player_spawn_points = spawnPointDict
 	#spawn players
-	rpc("createPlayers", Network.get_player_names(), spawnPointDict)
+	#rpc("createPlayers", Network.get_player_names(), spawnPointDict)
+
+func state_changed_priority(old_state: int, new_state, priority: int):
+	if priority != 5:
+		return
+	if new_state == GameManager.State.Lobby or new_state == GameManager.State.Normal:
+		rpc("createPlayers", Network.get_player_names(), player_spawn_points)
 
 func _on_infiltrator_kill(killer: KinematicBody2D, killed_player: KinematicBody2D) -> void:
 	"""

--- a/src/assets/main/maps.gd
+++ b/src/assets/main/maps.gd
@@ -10,10 +10,12 @@ func _ready() -> void:
 	set_network_master(1)
 	switchMap(currentMap)
 # warning-ignore:return_value_discarded
-	GameManager.connect('state_changed', self, '_on_state_change')
+	GameManager.connect("state_changed_priority", self, "_on_state_changed_priority")
 
 # warning-ignore:unused_argument
-func _on_state_change(old_state, new_state) -> void:
+func _on_state_changed_priority(old_state: int, new_state: int, priority: int) -> void:
+	if priority != 1:
+		return
 	match new_state:
 		GameManager.State.Lobby:
 			switchMap('lobby')

--- a/src/assets/maps/common/dynamic/testdoor/testdoor.gd
+++ b/src/assets/maps/common/dynamic/testdoor/testdoor.gd
@@ -7,8 +7,6 @@ var open: bool = false
 func _ready():
 # warning-ignore:return_value_discarded
 	MapManager.connect("interacted_with", self, "interacted_with")
-# warning-ignore:return_value_discarded
-	GameManager.connect("state_changed", self, "state_changed")
 
 func toggle(newState: bool = not open):
 	if newState:
@@ -38,10 +36,3 @@ func interacted_with(interactNode: Node, from: Node, interact_data: Dictionary):
 	if not from.has_method("get_state"):
 		return
 	toggle(from.get_state())
-
-# warning-ignore:unused_argument
-# warning-ignore:unused_argument
-func state_changed(old_state, new_state):
-	pass
-	#if new_state == GameManager.State.Normal:
-	#	MapManager.interact_with(self)


### PR DESCRIPTION
* Added a new signal to the game manager, ```state_changed_priority```. It is identical to ```state_changed```, except it also passes a priority int.
## HOW IT WORKS
When the game state is changed, GameManager will emit ```state_changed_priority``` several times, with incrementing priority. The first time it is emitted the priority will be 0, the next it will be 1, etc.. No additional network syncing is added.
## HOW TO USE
To use this new signal you connect it to a function in your script. Example:
```gdscript
func _ready():
	set_network_master(1)
	GameManager.connect("state_changed_priority", self, "state_changed_priority")

func state_changed_priority(old_state, new_state, priority):
	# we want to do something on priority 2
	if priority != 2:
		return
	match new_state:
		# we want to do something when the game transitions to the Normal state
		GameManager.State.Normal:
			do_thing()
```
## NOTES
The normal ```state_changed``` signal is emitted after all of the priority signals.

Each priority level is used for a certain thing: 
### Priority 0
Switching main scenes in ```scenemanager.gd``` and toggling accept/refuse connections in ```network.gd```

Priority 0 should be reserved for cleanup and extremely essential functions.
### Priority 1
Switching map in ```maps.gd```
### Priority 2
Assigning roles in ```playermanager.gd```
### Priority 3-4
Currently unused.
### Priority 5
Spawning players in ```main.gd```