### PR TITLE
Added network syncing to map interactions

### DIFF
--- a/src/addons/opensusinteraction/resources/interactmap/interactmap.gd
+++ b/src/addons/opensusinteraction/resources/interactmap/interactmap.gd
@@ -11,6 +11,8 @@ var attached_to: Node
 #data to pass to the UI node
 export(Dictionary) var interact_data
 
+var network_sync: bool = false
+
 var reported_interact_data: Dictionary = {}
 
 #called to execute the interaction this resource is customized for
@@ -22,7 +24,7 @@ func interact(_from: Node, _interact_data: Dictionary = {}):
 		return
 	#print("InteractMap attached_to: ", attached_to)
 	#print(attached_to.get_node(interact_with))
-	MapManager.interact_with(attached_to.get_node(interact_with), attached_to, _interact_data)
+	MapManager.interact_with(attached_to.get_node(interact_with), attached_to, _interact_data, network_sync)
 
 func init_resource(_from: Node, interact_data: Dictionary = {}):
 	if attached_to == null and _from != null:
@@ -61,17 +63,26 @@ func _init():
 #match actual var names
 func _set(property, value):
 	pass
-#	match property:
+	match property:
+		"advanced/network_sync":
+			network_sync = value
 
 #overrides get(), allows for export var groups and display properties that don't
 #match actual var names
 func _get(property):
 	pass
-#	match property:
+	match property:
+		"advanced/network_sync":
+			return network_sync
 
 #overrides get_property_list(), tells editor to show more vars in inspector
 func _get_property_list():
 	#if not Engine.editor_hint:
 	#	return []
 	var property_list: Array = []
+	property_list.append({"name": "advanced/network_sync",
+		"type": TYPE_BOOL,
+		"usage": PROPERTY_USAGE_DEFAULT,
+		"hint": PROPERTY_HINT_NONE,
+		})
 	return property_list

--- a/src/addons/opensusinteraction/resources/interactmap/interactmap.tres
+++ b/src/addons/opensusinteraction/resources/interactmap/interactmap.tres
@@ -10,3 +10,4 @@ interact_with = NodePath("")
 interact_data = {
 
 }
+advanced/network_sync = false

--- a/src/assets/autoload/helpers.gd
+++ b/src/assets/autoload/helpers.gd
@@ -30,3 +30,24 @@ func list_directory(path: String, recursive: bool = false) -> Array:
 
 func map(in_value: float, in_value_min: float, in_value_max: float, out_value_min: float, out_value_max: float) -> float:
 	return (in_value - in_value_min) * (out_value_max - out_value_min) / (in_value_max - in_value_min) + out_value_min
+
+func get_absolute_path_to(node: Node, subname: String = ""):
+	var path: String = get_tree().get_root().get_path_to(node)
+	if subname != "":
+		path = path + ":" + subname
+	return NodePath(path)
+
+func get_node_from_root(path: NodePath):
+	return get_tree().get_root().get_node(path)
+
+func get_node_or_null_from_root(path: NodePath):
+	if not get_node_from_root(path):
+		return null
+	return get_node_from_root(path)
+
+# get property from NodePath, for ex. get_node_property_from_root("UIManager:current_ui") will return the value of current_ui
+# input path to node from root
+func get_node_property_from_root(path: NodePath):
+	var node = get_node_from_root(path)
+	var subnames = path.get_concatenated_subnames()
+	return node.get_indexed(subnames)

--- a/src/assets/autoload/mapmanager.gd
+++ b/src/assets/autoload/mapmanager.gd
@@ -29,43 +29,67 @@ func broadcast_map_interaction(interact_node: Node, from: Node, interact_data: D
 	if from == null:
 		push_error("failed to broadcast interaction, from is null")
 		return
-	var root = get_tree().get_root()
-	var interact_node_path = root.get_path_to(interact_node)
-	var from_node_path = root.get_path_to(from)
+	var interact_node_path = Helpers.get_absolute_path_to(interact_node)
+	var from_node_path = Helpers.get_absolute_path_to(from)
+	var parsed_data: Dictionary = parse_for_networking(interact_data)
 	if get_tree().is_network_server():
-		rpc("receive_map_interaction", interact_node_path, from_node_path, interact_data)
+		rpc("receive_map_interaction", interact_node_path, from_node_path, parsed_data)
 	else:
-		rpc_id(1, "receive_map_interaction_server", interact_node_path, from_node_path, interact_data)
+		rpc_id(1, "receive_map_interaction_server", interact_node_path, from_node_path, parsed_data)
 
-puppet func receive_map_interaction(interact_node_path: NodePath, from_node_path: NodePath, interact_data: Dictionary = {}):
+puppet func receive_map_interaction(interact_node_path: NodePath, from_node_path: NodePath, parsed_data: Dictionary = {}):
 	if get_tree().is_network_server():
 		return
-	var root = get_tree().get_root()
-	var interact_node = root.get_node_or_null(interact_node_path)
-	var from = root.get_node_or_null(from_node_path)
+	var interact_node = Helpers.get_node_or_null_from_root(interact_node_path)
+	var from = Helpers.get_node_or_null_from_root(from_node_path)
 	if interact_node == null:
 		push_error("failed to receive interaction, trying to interact with a null instance")
 		return
 	if from == null:
 		push_error("failed to receive interaction, from is null")
 		return
+	var interact_data: Dictionary = parse_from_networking(parsed_data)
 	emit_signal("interacted_with", interact_node, from, interact_data)
 
 # right now any client can rpc this function and execute any map interaction they want, this is extremely easy to exploit
 # for now I'm going to disable this function, if you have any ideas on how to make this safer please share!
-remote func receive_map_interaction_server(interact_node_path: NodePath, from_node_path: NodePath, interact_data: Dictionary = {}):
+remote func receive_map_interaction_server(interact_node_path: NodePath, from_node_path: NodePath, parsed_data: Dictionary = {}):
 	# or true is so that this function will not do anything
 	if not get_tree().is_network_server() or true:
 		return
-	var root = get_tree().get_root()
-	var interact_node = root.get_node_or_null(interact_node_path)
-	var from = root.get_node_or_null(from_node_path)
+	var interact_node = Helpers.get_node_or_null_from_root(interact_node_path)
+	var from = Helpers.get_node_or_null_from_root(from_node_path)
 	if interact_node == null:
 		push_error("failed to receive interaction, trying to interact with a null instance")
 		return
 	if from == null:
 		push_error("failed to receive interaction, from is null")
 		return
+	var interact_data: Dictionary = parse_from_networking(parsed_data)
 	# verify interaction here? I'm not sure how you could verify it
-	broadcast_map_interaction(interact_node, from, interact_data)
+	broadcast_map_interaction(interact_node, from, parsed_data)
 	emit_signal("interacted_with", interact_node, from, interact_data)
+
+# for encoding interact_data in a way that preserves nodes
+func parse_for_networking(dict: Dictionary):
+	var node_keys: Array = gen_node_keys(dict)
+	var parsed_dict: Dictionary = dict
+	for key in node_keys:
+		parsed_dict[key] = Helpers.get_absolute_path_to(dict[key])
+	var return_dict: Dictionary = {}
+	return_dict["node_keys"] = node_keys
+	return_dict["parsed_dict"] = parsed_dict
+	return return_dict
+
+func parse_from_networking(dict: Dictionary):
+	var return_dict = dict["parsed_dict"]
+	for key in dict["node_keys"]:
+		return_dict[key] = Helpers.get_node_or_null_from_root(return_dict[key])
+	return return_dict
+
+func gen_node_keys(dict: Dictionary) -> Array:
+	var node_keys: Array = []
+	for key in dict.keys():
+		if dict[key] is Node:
+			node_keys.append(key)
+	return node_keys

--- a/src/assets/autoload/mapmanager.gd
+++ b/src/assets/autoload/mapmanager.gd
@@ -1,26 +1,71 @@
 extends Node
 
-
-
 signal interacted_with
 
 func _ready():
-# warning-ignore:return_value_discarded
-	GameManager.connect("state_changed", self, "state_changed")
+	set_network_master(1)
 
 #each interactable node will store info about what should happen when it is
 #interacted with, just sending the node lets the receiver handle it completely
 #it also prevents this script from limiting the game
 #from is where the interaction came from (player, button, etc.)
-func interact_with(interactNode: Node, from: Node, interact_data: Dictionary = {}):
+func interact_with(interact_node: Node, from: Node, interact_data: Dictionary = {}, broadcast: bool = false):
 	#put checks and stuff here
 	#print("signalling interact with ", interactNode.name)
-	if interactNode == null or from == null:
-		print("failed to interact, trying to interact with a null instance")
+	if interact_node == null:
+		push_error("failed to interact, trying to interact with a null instance")
 		return
-	emit_signal("interacted_with", interactNode, from, interact_data)
+	if from == null:
+		push_error("failed to interact, from is null")
+		return
+	if broadcast:
+		broadcast_map_interaction(interact_node, from, interact_data)
+	emit_signal("interacted_with", interact_node, from, interact_data)
 
-# warning-ignore:unused_argument
-# warning-ignore:unused_argument
-func state_changed(old_state, new_state):
-	pass
+func broadcast_map_interaction(interact_node: Node, from: Node, interact_data: Dictionary = {}):
+	if interact_node == null:
+		push_error("failed to broadcast interaction, trying to interact with a null instance")
+		return
+	if from == null:
+		push_error("failed to broadcast interaction, from is null")
+		return
+	var root = get_tree().get_root()
+	var interact_node_path = root.get_path_to(interact_node)
+	var from_node_path = root.get_path_to(from)
+	if get_tree().is_network_server():
+		rpc("receive_map_interaction", interact_node_path, from_node_path, interact_data)
+	else:
+		rpc_id(1, "receive_map_interaction_server", interact_node_path, from_node_path, interact_data)
+
+puppet func receive_map_interaction(interact_node_path: NodePath, from_node_path: NodePath, interact_data: Dictionary = {}):
+	if get_tree().is_network_server():
+		return
+	var root = get_tree().get_root()
+	var interact_node = root.get_node_or_null(interact_node_path)
+	var from = root.get_node_or_null(from_node_path)
+	if interact_node == null:
+		push_error("failed to receive interaction, trying to interact with a null instance")
+		return
+	if from == null:
+		push_error("failed to receive interaction, from is null")
+		return
+	emit_signal("interacted_with", interact_node, from, interact_data)
+
+# right now any client can rpc this function and execute any map interaction they want, this is extremely easy to exploit
+# for now I'm going to disable this function, if you have any ideas on how to make this safer please share!
+remote func receive_map_interaction_server(interact_node_path: NodePath, from_node_path: NodePath, interact_data: Dictionary = {}):
+	# or true is so that this function will not do anything
+	if not get_tree().is_network_server() or true:
+		return
+	var root = get_tree().get_root()
+	var interact_node = root.get_node_or_null(interact_node_path)
+	var from = root.get_node_or_null(from_node_path)
+	if interact_node == null:
+		push_error("failed to receive interaction, trying to interact with a null instance")
+		return
+	if from == null:
+		push_error("failed to receive interaction, from is null")
+		return
+	# verify interaction here? I'm not sure how you could verify it
+	broadcast_map_interaction(interact_node, from, interact_data)
+	emit_signal("interacted_with", interact_node, from, interact_data)


### PR DESCRIPTION
## GENERAL CHANGES
* You can now pass a bool in ```interact_with()``` to choose whether or not to sync the interaction over the network. It is the 4th input and optional.
* mapmanager.gd now uses ```push_error()``` instead of ```print()``` to display errors

## NEW HELPERS
```gdscript
var node = get_node("MyButton")

# returns path to node from root AKA absolute path
# ex. output: "Main/uicontroller/MyButton"
var absolute_path = Helpers.get_absolute_path_to(node)

# gets node from absolute path
# ex. output: [Button:1853]
Helpers.get_node_from_root(absolute_path)

# gets node from absolute path, if node does not exist returns null
Helpers.get_node_or_null_from_root(absolute_path)

# a property path points to a property (variable) within a node
# this path is pointing to the name variable inside the Button node
var property_path = Helpers.get_absolute_path_to(node) + ":name" # "Main/uicontroller/Button:name"

# returns value of the property that the property path points to
# ex. output: "MyButton"
Helpers.get_node_property_from_root(property_path)
```

## NOTES
* Nodes sent in ```interact_data``` will be retained when sent over network, but resources will not
* Clients cannot send map interactions to be synced. This is disabled for now because it is hilariously easy to exploit and I don't know how you would verify a map interaction