### PR TITLE
Improving UI system/InteractUI resources

### DIFF
--- a/src/addons/opensusinteraction/resources/interact/interact.tres
+++ b/src/addons/opensusinteraction/resources/interact/interact.tres
@@ -24,6 +24,7 @@ ui_name = ""
 ui_data = {
 
 }
+action = 0
 advanced/reinstance = false
 advanced/only_instance = false
 

--- a/src/addons/opensusinteraction/resources/interact/interact.tres
+++ b/src/addons/opensusinteraction/resources/interact/interact.tres
@@ -26,7 +26,7 @@ ui_data = {
 }
 action = 0
 advanced/reinstance = false
-advanced/only_instance = false
+advanced/free_on_close = false
 
 [sub_resource type="Resource" id=3]
 resource_local_to_scene = true

--- a/src/addons/opensusinteraction/resources/interacttask/interacttask.tres
+++ b/src/addons/opensusinteraction/resources/interacttask/interacttask.tres
@@ -11,6 +11,7 @@ ui_name = ""
 ui_data = {
 
 }
+action = 0
 advanced/reinstance = false
 advanced/only_instance = false
 

--- a/src/addons/opensusinteraction/resources/interacttask/interacttask.tres
+++ b/src/addons/opensusinteraction/resources/interacttask/interacttask.tres
@@ -13,7 +13,7 @@ ui_data = {
 }
 action = 0
 advanced/reinstance = false
-advanced/only_instance = false
+advanced/free_on_close = false
 
 [resource]
 resource_local_to_scene = true

--- a/src/addons/opensusinteraction/resources/interactui/interactui.gd
+++ b/src/addons/opensusinteraction/resources/interactui/interactui.gd
@@ -15,16 +15,21 @@ export(actions) var action
 #whether or not to delete and recreate the UI node before opening
 var reinstance: bool = false
 
-var only_instance: bool = false
+var free_on_close: bool = false
 
 var interact_data: Dictionary = {}
 
 #called to execute the interaction this resource is customized for
 func interact(_from: Node = null, _interact_data: Dictionary = {}):
-	if only_instance:
-		UIManager.instance_ui(ui_name, get_interact_data(_from, _interact_data))
-	else:
-		UIManager.open_ui(ui_name, get_interact_data(_from, _interact_data), reinstance)
+	match action:
+		actions.OPEN:
+			open(_from, _interact_data)
+		actions.INSTANCE:
+			instance(_from, _interact_data)
+		actions.UPDATE:
+			update(_from, _interact_data)
+		actions.CLOSE:
+			close()
 
 func open(_from: Node = null, _interact_data: Dictionary = {}, reinstance: bool = self.reinstance):
 	UIManager.open_ui(ui_name, get_interact_data(_from, _interact_data), reinstance)
@@ -35,7 +40,7 @@ func instance(_from: Node = null, _interact_data: Dictionary = {}):
 func update(_from: Node = null, _interact_data: Dictionary = {}):
 	UIManager.update_ui(ui_name, get_interact_data(_from, _interact_data))
 
-func close(free: bool = false):
+func close(free: bool = free_on_close):
 	UIManager.close_ui(ui_name, free)
 
 func init_resource(_from: Node = null):
@@ -67,8 +72,8 @@ func _set(property, value):
 	match property:
 		"advanced/reinstance":
 			reinstance = value
-		"advanced/only_instance":
-			only_instance = value
+		"advanced/free_on_close":
+			free_on_close = value
 
 #overrides get(), allows for export var groups and display properties that don't
 #match actual var names
@@ -76,8 +81,8 @@ func _get(property):
 	match property:
 		"advanced/reinstance":
 			return reinstance
-		"advanced/only_instance":
-			return only_instance
+		"advanced/free_on_close":
+			return free_on_close
 
 #overrides get_property_list(), tells editor to show more vars in inspector
 func _get_property_list():
@@ -89,7 +94,7 @@ func _get_property_list():
 		"usage": PROPERTY_USAGE_DEFAULT,
 		"hint": PROPERTY_HINT_NONE,
 		})
-	property_list.append({"name": "advanced/only_instance",
+	property_list.append({"name": "advanced/free_on_close",
 		"type": TYPE_BOOL,
 		"usage": PROPERTY_USAGE_DEFAULT,
 		"hint": PROPERTY_HINT_NONE,

--- a/src/addons/opensusinteraction/resources/interactui/interactui.gd
+++ b/src/addons/opensusinteraction/resources/interactui/interactui.gd
@@ -8,6 +8,9 @@ export(String) var ui_name
 #data to pass to the UI node
 export(Dictionary) var ui_data
 
+enum actions {OPEN, INSTANCE, UPDATE, CLOSE}
+export(actions) var action
+
 #changed in the editor via overriding get(), set(), and get_property_list()
 #whether or not to delete and recreate the UI node before opening
 var reinstance: bool = false
@@ -26,8 +29,11 @@ func interact(_from: Node = null, _interact_data: Dictionary = {}):
 func open(_from: Node = null, _interact_data: Dictionary = {}, reinstance: bool = self.reinstance):
 	UIManager.open_ui(ui_name, get_interact_data(_from, _interact_data), reinstance)
 
-func update(_from: Node = null, _interact_data: Dictionary = {}, reinstance: bool = self.reinstance):
-	pass
+func instance(_from: Node = null, _interact_data: Dictionary = {}):
+	UIManager.instance_ui(ui_name, get_interact_data(_from, _interact_data))
+
+func update(_from: Node = null, _interact_data: Dictionary = {}):
+	UIManager.update_ui(ui_name, get_interact_data(_from, _interact_data))
 
 func close(free: bool = false):
 	UIManager.close_ui(ui_name, free)

--- a/src/addons/opensusinteraction/resources/interactui/interactui.gd
+++ b/src/addons/opensusinteraction/resources/interactui/interactui.gd
@@ -23,6 +23,15 @@ func interact(_from: Node = null, _interact_data: Dictionary = {}):
 	else:
 		UIManager.open_ui(ui_name, get_interact_data(_from, _interact_data), reinstance)
 
+func open(_from: Node = null, _interact_data: Dictionary = {}, reinstance: bool = self.reinstance):
+	UIManager.open_ui(ui_name, get_interact_data(_from, _interact_data), reinstance)
+
+func update(_from: Node = null, _interact_data: Dictionary = {}, reinstance: bool = self.reinstance):
+	pass
+
+func close(free: bool = false):
+	UIManager.close_ui(ui_name, free)
+
 func init_resource(_from: Node = null):
 	pass
 

--- a/src/addons/opensusinteraction/resources/interactui/interactui.tres
+++ b/src/addons/opensusinteraction/resources/interactui/interactui.tres
@@ -10,5 +10,6 @@ ui_name = ""
 ui_data = {
 
 }
+action = 0
 advanced/reinstance = false
 advanced/only_instance = false

--- a/src/addons/opensusinteraction/resources/interactui/interactui.tres
+++ b/src/addons/opensusinteraction/resources/interactui/interactui.tres
@@ -12,4 +12,4 @@ ui_data = {
 }
 action = 0
 advanced/reinstance = false
-advanced/only_instance = false
+advanced/free_on_close = false

--- a/src/assets/autoload/helpers.gd
+++ b/src/assets/autoload/helpers.gd
@@ -34,6 +34,7 @@ func map(in_value: float, in_value_min: float, in_value_max: float, out_value_mi
 
 func get_absolute_path_to(node: Node, subname: String = ""):
 	var path: String = get_tree().get_root().get_path_to(node)
+	path = "/root/" + path
 	if subname != "":
 		path = path + ":" + subname
 	return NodePath(path)

--- a/src/assets/autoload/helpers.gd
+++ b/src/assets/autoload/helpers.gd
@@ -53,3 +53,36 @@ func get_node_property_from_root(path: NodePath):
 	var node = get_node_from_root(path)
 	var subnames = path.get_concatenated_subnames()
 	return node.get_indexed(subnames)
+
+func object_has_method_with_args(object: Object, method: String, args: Array) -> bool:
+	var method_args: Array = get_object_method_arg_names(object, method)
+	for arg in args:
+		if not method_args.has(arg):
+			return false
+	return true
+
+func object_has_method_with_arg(object: Object, method: String, arg: String) -> bool:
+	var method_args: Array = get_object_method_arg_names(object, method)
+	var arg_names
+	return method_args.has(arg)
+
+func get_object_method_arg_amount(object: Object, method: String) -> int:
+	return get_object_method_args(object, method).size()
+
+func get_object_method_arg_names(object: Object, method: String) -> Array:
+	var method_args: Array = get_object_method_args(object, method)
+	var arg_names: Array = []
+	for arg in method_args:
+		arg_names.append(arg["name"])
+	print(arg_names)
+	return arg_names
+
+func get_object_method_args(object: Object, method: String) -> Array:
+	var object_methods: Array = object.get_method_list()
+	for method_data in object_methods:
+		if method_data["name"] != method:
+			continue
+		print(method_data)
+		print(method_data["args"])
+		return method_data["args"]
+	return []

--- a/src/assets/autoload/uimanager.gd
+++ b/src/assets/autoload/uimanager.gd
@@ -37,9 +37,6 @@ signal update_ui(ui_name, ui_data)
 signal free_ui(ui_name)
 
 func _ready():
-	print(Helpers.object_has_method_with_arg(self, "open_ui", "ui_name"))
-#	print(Helpers.get_absolute_path_to(self))
-#	print(get_node(Helpers.get_absolute_path_to(self)))
 	configfile = ConfigFile.new()
 	configfile.load(filepath)
 	check_keybinds(configfile)

--- a/src/assets/autoload/uimanager.gd
+++ b/src/assets/autoload/uimanager.gd
@@ -33,12 +33,13 @@ var ui_controller_node: Node
 signal open_ui(ui_name, ui_data, reinstance)
 signal close_ui(ui_name, free)
 signal instance_ui(ui_name, ui_data)
+signal update_ui(ui_name, ui_data)
 signal free_ui(ui_name)
 
 func _ready():
-#	print(get_method_list())
-	print(Helpers.get_absolute_path_to(self))
-	print(get_node(Helpers.get_absolute_path_to(self)))
+	print(Helpers.object_has_method_with_arg(self, "open_ui", "ui_name"))
+#	print(Helpers.get_absolute_path_to(self))
+#	print(get_node(Helpers.get_absolute_path_to(self)))
 	configfile = ConfigFile.new()
 	configfile.load(filepath)
 	check_keybinds(configfile)
@@ -73,6 +74,11 @@ func instance_ui(ui_name: String, ui_data: Dictionary = {}):
 	if not ui_list.keys().has(ui_name):
 		push_error("instance_ui() called with invalid ui name " + ui_name)
 	emit_signal("instance_ui", ui_name, ui_data)
+
+func update_ui(ui_name: String, ui_data: Dictionary = {}):
+	if not ui_list.keys().has(ui_name):
+		push_error("update_ui() called with invalid ui name " + ui_name)
+	emit_signal("update_ui", ui_name, ui_data)
 
 func free_ui(ui_name: String):
 	if not ui_list.keys().has(ui_name):

--- a/src/assets/autoload/uimanager.gd
+++ b/src/assets/autoload/uimanager.gd
@@ -35,6 +35,7 @@ signal close_ui(ui_name, free)
 signal instance_ui(ui_name, ui_data)
 signal update_ui(ui_name, ui_data)
 signal free_ui(ui_name)
+signal close_all_ui()
 
 func _ready():
 	configfile = ConfigFile.new()
@@ -81,6 +82,9 @@ func free_ui(ui_name: String):
 	if not ui_list.keys().has(ui_name):
 		push_error("free_ui() called with invalid ui name " + ui_name)
 	emit_signal("free_ui", ui_name)
+
+func close_all_ui(free: bool = false):
+	emit_signal("close_all_ui", free)
 
 func get_ui(ui_name: String):
 	if not ui_list.keys().has(ui_name):

--- a/src/assets/autoload/uimanager.gd
+++ b/src/assets/autoload/uimanager.gd
@@ -36,6 +36,9 @@ signal instance_ui(ui_name, ui_data)
 signal free_ui(ui_name)
 
 func _ready():
+#	print(get_method_list())
+	print(Helpers.get_absolute_path_to(self))
+	print(get_node(Helpers.get_absolute_path_to(self)))
 	configfile = ConfigFile.new()
 	configfile.load(filepath)
 	check_keybinds(configfile)

--- a/src/assets/common/classes/ui/base/controlbase.gd
+++ b/src/assets/common/classes/ui/base/controlbase.gd
@@ -13,7 +13,6 @@ func _init():
 
 #called by ui system
 func base_open():
-	print(filename)
 	show()
 
 #called by self or ui system

--- a/src/assets/common/classes/ui/base/controlbase.gd
+++ b/src/assets/common/classes/ui/base/controlbase.gd
@@ -13,6 +13,7 @@ func _init():
 
 #called by ui system
 func base_open():
+	print(filename)
 	show()
 
 #called by self or ui system

--- a/src/assets/player/infiltrator.tscn
+++ b/src/assets/player/infiltrator.tscn
@@ -3,21 +3,21 @@
 [ext_resource path="res://addons/opensusinteraction/resources/interactui/interactui.gd" type="Script" id=1]
 [ext_resource path="res://assets/player/infiltrator.gd" type="Script" id=2]
 
-[sub_resource type="Resource" id=3]
+[sub_resource type="Resource" id=1]
 resource_local_to_scene = true
 script = ExtResource( 1 )
 ui_name = "killui"
 ui_data = {
 
 }
+action = 0
 advanced/reinstance = false
-advanced/only_instance = true
+advanced/free_on_close = false
 
-[sub_resource type="CircleShape2D" id=1]
+[sub_resource type="CircleShape2D" id=2]
 radius = 60.0
 
-[sub_resource type="Animation" id=2]
-resource_name = "Reload"
+[sub_resource type="Animation" id=3]
 length = 10.0
 
 [node name="Infiltrator" type="Node2D" groups=[
@@ -27,7 +27,7 @@ script = ExtResource( 2 )
 __meta__ = {
 "_editor_description_": "Node that gets instantiated as a child of a player when they are assigned the role of \"traitor\"."
 }
-ui_interact_resource = SubResource( 3 )
+ui_interact_resource = SubResource( 1 )
 
 [node name="KillCooldownTimer" type="Timer" parent="."]
 wait_time = 10.0
@@ -44,13 +44,13 @@ __meta__ = {
 }
 
 [node name="KillCollision" type="CollisionShape2D" parent="KillArea"]
-shape = SubResource( 1 )
+shape = SubResource( 2 )
 __meta__ = {
 "_editor_description_": "The collision of the area where a player may be killed."
 }
 
 [node name="Animator" type="AnimationPlayer" parent="."]
-anims/Reload = SubResource( 2 )
+anims/Reload = SubResource( 3 )
 __meta__ = {
 "_editor_description_": "AnimationPlayer responsible for controller Infiltrator specific animations."
 }

--- a/src/assets/player/player.gd
+++ b/src/assets/player/player.gd
@@ -62,6 +62,9 @@ func _ready():
 	#TODO: tell the player node their role upon creation in main.gd
 	roles_assigned(PlayerManager.get_player_roles())
 # warning-ignore:return_value_discarded
+	# connecting this signal causes the player node to receive it during round
+	# switching and before the new player nodes are spawned
+	# players should probably be deleted in the cleanup phase
 #	PlayerManager.connect("roles_assigned", self, "roles_assigned")
 	AppearanceManager.connect("apply_appearance", self, "customizePlayer")
 	customizePlayer(id)

--- a/src/assets/player/player.gd
+++ b/src/assets/player/player.gd
@@ -62,7 +62,7 @@ func _ready():
 	#TODO: tell the player node their role upon creation in main.gd
 	roles_assigned(PlayerManager.get_player_roles())
 # warning-ignore:return_value_discarded
-	PlayerManager.connect("roles_assigned", self, "roles_assigned")
+#	PlayerManager.connect("roles_assigned", self, "roles_assigned")
 	AppearanceManager.connect("apply_appearance", self, "customizePlayer")
 	customizePlayer(id)
 

--- a/src/assets/ui/uicontroller/uicontroller.gd
+++ b/src/assets/ui/uicontroller/uicontroller.gd
@@ -82,10 +82,10 @@ func update_ui(ui_name: String, ui_data: Dictionary = {}):
 	var current_ui = get_ui(ui_name)
 	if ui_data != {} and current_ui.get("ui_data") != null:
 		current_ui.ui_data = ui_data
-	#call close on a lower class, handles ui system integration
+	#call update on a lower class, handles ui system integration
 	if current_ui.has_method("base_update"):
 		current_ui.base_update()
-	#call close on the inherited class, most likely the script attached to a given task or menu
+	#call update on the inherited class, most likely the script attached to a given task or menu
 	if current_ui.has_method("update"):
 		current_ui.update()
 

--- a/src/assets/ui/uicontroller/uicontroller.gd
+++ b/src/assets/ui/uicontroller/uicontroller.gd
@@ -73,6 +73,20 @@ func instance_ui(ui_name: String, ui_data: Dictionary = {}):
 	instanced_uis[ui_name] = new_ui
 	add_child(new_ui)
 
+func update_ui(ui_name: String, ui_data: Dictionary = {}):
+	update_instanced_uis()
+	if not instanced_uis.has(ui_name):
+		return
+	var current_ui = get_ui(ui_name)
+	if ui_data != {} and current_ui.get("ui_data") != null:
+		current_ui.ui_data = ui_data
+	#call close on a lower class, handles ui system integration
+	if current_ui.has_method("base_update"):
+		current_ui.base_update()
+	#call close on the inherited class, most likely the script attached to a given task or menu
+	if current_ui.has_method("update"):
+		current_ui.update()
+
 func free_ui(ui_name: String):
 	var current_ui = get_ui(ui_name)
 	if current_ui == null:

--- a/src/assets/ui/uicontroller/uicontroller.gd
+++ b/src/assets/ui/uicontroller/uicontroller.gd
@@ -18,6 +18,8 @@ func _ready():
 # warning-ignore:return_value_discarded
 	UIManager.connect("instance_ui", self, "instance_ui")
 # warning-ignore:return_value_discarded
+	UIManager.connect("update_ui", self, "update_ui")
+# warning-ignore:return_value_discarded
 	UIManager.connect("free_ui", self, "free_ui")
 	var err = config.load("user://settings.cfg")
 	if err == OK:

--- a/src/assets/ui/uicontroller/uicontroller.gd
+++ b/src/assets/ui/uicontroller/uicontroller.gd
@@ -21,6 +21,8 @@ func _ready():
 	UIManager.connect("update_ui", self, "update_ui")
 # warning-ignore:return_value_discarded
 	UIManager.connect("free_ui", self, "free_ui")
+# warning-ignore:return_value_discarded
+	UIManager.connect("close_all_ui", self, "close_all_ui")
 	var err = config.load("user://settings.cfg")
 	if err == OK:
 		$ColorblindRect.material.set_shader_param(
@@ -94,6 +96,10 @@ func free_ui(ui_name: String):
 	if current_ui == null:
 		return
 	current_ui.queue_free()
+
+func close_all_ui(free: bool = false):
+	for ui in UIManager.open_uis:
+		close_ui(ui, free)
 
 func get_ui(ui_name: String):
 	update_instanced_uis()


### PR DESCRIPTION
InteractUI resources can now be used to open, update, instance, and close UIs instead of only being able to open UIs. Also added individual functions in interactui.gd to open, update, instance, and close UIs so you don't need multiple resources interacting with the same UI. 

Updating a UI only passes it new data and calls ```base_update()``` and ```update()``` on the UI (if the UI script has those methods).

I plan to switch the UI system to use file paths to UI scenes instead of a dictionary in uimanager.gd. I'm also probably going to move away from using custom types (with the plugin) and just use custom classes because they are better in almost every way (and custom types are probably getting removed from Godot soon). It would also keep interaction resources from showing up in random dropdowns meant for a specific type of resource. 