### PR TITLE
Keep camera centered on player

### DIFF
--- a/src/assets/player/player.tscn
+++ b/src/assets/player/player.tscn
@@ -95,10 +95,10 @@ zoom = Vector2( 0.5, 0.5 )
 drag_margin_h_enabled = true
 drag_margin_v_enabled = true
 smoothing_enabled = true
-drag_margin_left = 0.65
-drag_margin_top = 0.65
-drag_margin_right = 0.65
-drag_margin_bottom = 0.65
+drag_margin_left = 0.0
+drag_margin_top = 0.0
+drag_margin_right = 0.0
+drag_margin_bottom = 0.0
 script = ExtResource( 27 )
 
 [node name="Label" type="Label" parent="."]


### PR DESCRIPTION
Looking for some feedback on this idea, I think it's nicer to have the camera centered on the player instead of waiting for them to walk to the edge of the screen. Gives you a better sense of what's around you, more "awareness", feels less claustrophobic.