### PR TITLE
Quick fix to unassigned global tasks

### DIFF
--- a/src/addons/opensusinteraction/resources/interacttask/interacttask.gd
+++ b/src/addons/opensusinteraction/resources/interacttask/interacttask.gd
@@ -421,9 +421,9 @@ func get_task_state(player_id: int) -> int:
 	return task_data_player[player_id]["state"]
 
 func is_player_assigned(player_id: int) -> bool:
-	# it does not return true if the task is global because it is not going to be assigned
+	# it does not return true if the task is global because it is not guaranteed to be assigned
 	# 	every round
-	# it should stay this way because it allows the game to choose which global tasks
+	# this allows the game to choose which global tasks to have in each round
 	# 	to have in each round
 #	if is_task_global():
 #		return true

--- a/src/addons/opensusinteraction/resources/interacttask/interacttask.gd
+++ b/src/addons/opensusinteraction/resources/interacttask/interacttask.gd
@@ -427,7 +427,7 @@ func is_player_assigned(player_id: int) -> bool:
 	# 	to have in each round
 #	if is_task_global():
 #		return true
-	return task_data_player.has(player_id)
+	return task_data_player.has(normalize_player_id(player_id))
 
 func is_task_global() -> bool:
 	return task_data["is_task_global"]

--- a/src/addons/opensusinteraction/resources/interacttask/interacttask.gd
+++ b/src/addons/opensusinteraction/resources/interacttask/interacttask.gd
@@ -421,7 +421,7 @@ func get_task_state(player_id: int) -> int:
 	return task_data_player[player_id]["state"]
 
 func is_player_assigned(player_id: int) -> bool:
-	# it does not return true if the task is global because it is not guaranteed to be assigned
+	# it does not blindly return true if the task is global because it is not guaranteed to be assigned
 	# 	every round
 	# this allows the game to choose which global tasks to have in each round
 	# 	to have in each round

--- a/src/addons/opensusinteraction/resources/interacttask/interacttask.gd
+++ b/src/addons/opensusinteraction/resources/interacttask/interacttask.gd
@@ -421,8 +421,12 @@ func get_task_state(player_id: int) -> int:
 	return task_data_player[player_id]["state"]
 
 func is_player_assigned(player_id: int) -> bool:
-	if is_task_global():
-		return true
+	# it does not return true if the task is global because it is not going to be assigned
+	# 	every round
+	# it should stay this way because it allows the game to choose which global tasks
+	# 	to have in each round
+#	if is_task_global():
+#		return true
 	return task_data_player.has(player_id)
 
 func is_task_global() -> bool:


### PR DESCRIPTION
This fixes a crash that occurs when you try to interact with a global task that was not actually assigned to the global task ID by the task manager. Not making it so global tasks are always assigned so that the game can pick and choose which global tasks to have in each round.